### PR TITLE
Added new JobDriver_UnloadYourInventory and worked on Loadouts.

### DIFF
--- a/Defs/JobDefs/Jobs_Misc.xml
+++ b/Defs/JobDefs/Jobs_Misc.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <JobDefs>
 	<JobDef>
-		<defName>UnloadInventory</defName>
-		<driverClass>CombatExtended.JobDriver_UnloadInventory</driverClass>
-		<reportString>unloading TargetA.</reportString>
+		<defName>UnloadYourInventory</defName>
+		<driverClass>CombatExtended.JobDriver_UnloadYourInventory</driverClass>
+		<reportString>unloading inventory.</reportString>
 	</JobDef>
 </JobDefs>

--- a/Defs/JobDefs/Jobs_Misc.xml.disabled
+++ b/Defs/JobDefs/Jobs_Misc.xml.disabled
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<JobDefs>
+	<JobDef>
+		<defName>UnloadInventory</defName>
+		<driverClass>CombatExtended.JobDriver_UnloadInventory</driverClass>
+		<reportString>unloading TargetA.</reportString>
+	</JobDef>
+</JobDefs>

--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -156,12 +156,13 @@
     <Compile Include="CombatExtended\Jobs\JobDriver_Hunt.cs" />
     <Compile Include="CombatExtended\Jobs\JobDriver_Stabilize.cs" />
     <Compile Include="CombatExtended\Jobs\JobDriver_TakeFromOther.cs" />
-    <Compile Include="CombatExtended\Jobs\JobDriver_UnloadInventory.cs" />
+    <Compile Include="CombatExtended\Jobs\JobDriver_UnloadYourInventory.cs" />
     <Compile Include="CombatExtended\Jobs\JobGiver_ConfigurableHostilityResponse.cs" />
     <Compile Include="CombatExtended\Jobs\JobGiver_SquadDuty.cs" />
     <Compile Include="CombatExtended\Jobs\JobGiver_TakeAndEquip.cs" />
     <Compile Include="CombatExtended\Loadouts\HoldRecord.cs" />
-    <Compile Include="CombatExtended\Loadouts\HoldTracker.cs" />
+    <Compile Include="CombatExtended\Loadouts\HoldTrackerAssignment.cs" />
+    <Compile Include="CombatExtended\Loadouts\Utility_HoldTracker.cs" />
     <Compile Include="CombatExtended\Projectiles\ProjectileCE_Explosive_RL.cs" />
     <Compile Include="CombatExtended\ModSettings.cs" />
     <Compile Include="CombatExtended\Recipe_RemoveOldHediff.cs" />
@@ -268,7 +269,7 @@
     <Compile Include="Detours\Detours_VerbTracker.cs" />
     <Compile Include="Detours\Detours_WorkGiver_HunterHunt.cs" />
     <Compile Include="Detours\Detours_WorkGiver_InteractAnimal.cs" />
-    <Compile Include="Harmony\Harmony-HediffComp_TendDuration_Patch.cs" />
+    <Compile Include="Harmony\Harmony-HediffComp_TendDuration_CompTended_Patch.cs" />
     <Compile Include="Harmony\HarmonyBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CombatExtended\Verbs\Verb_ShootCE.cs" />

--- a/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompInventory.cs
@@ -179,9 +179,7 @@ namespace CombatExtended
                 ammoListCached.Clear();
                 meleeWeaponListCached.Clear();
                 rangedWeaponListCached.Clear();
-                Dictionary<ThingDef, HoldRecord> recs;
-                if (!HoldTracker.tracker.TryGetValue(parentPawn, out recs))
-                	recs = null;
+                List<HoldRecord> recs = LoadoutManager.GetHoldRecords(parentPawn);
                 foreach (Thing thing in parentPawn.inventory.innerContainer)
                 {
                     // Check for weapons
@@ -215,14 +213,11 @@ namespace CombatExtended
                     {
                         ammoListCached.Add(thing);
                     }
-					if (recs != null)
+                    if (recs != null)
 					{
-						HoldRecord rec;
-						if (recs.TryGetValue(thing.def, out rec))
-						{
-							if (!rec.pickedUp)
-								rec.pickedUp = true;
-						}
+                    	HoldRecord rec = recs.FirstOrDefault(hr => hr.thingDef == thing.def);
+						if (rec != null && !rec.pickedUp)
+							rec.pickedUp = true;
 					}
                 }
             }

--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutGenericDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutGenericDef.cs
@@ -5,23 +5,13 @@ using System.Linq.Expressions;
 using RimWorld;
 using Verse;
 
-/* Was originally designed to take information from XML and on game startup compile the string to a linq but an apt method of doing that wasn't found.
- * Now each def is generated programatically and this *should* catch new guns and ammo from other mods.
- * Unfortunately an issue remains that if you create a situation where the sets of ThingDefs that two generics create, say set1 and set2.
- *  If set1 != set2 && set1 intersect set2 != null then the loadouts won't quite function right.
- * The first pass on generics had generics define an upper bound so that if you had a specific covered by a generic and the specific's count was > generic
- *  no more items would get picked up.  If the specific count < generic count then the generic would pick up generic desired count - specific have count.
- * The current system is to count up as when the other system failed a drop/pickup loop could start.  Now with an attempt to fill out each slot
- * instead not everything desired will be picked up but not loops should start.
+/* Keep the following list up to date:
+ * Currently defined Generics:
+ * -for Meals - Pawns auto fetch a best food, generaly meals
+ * -for Raw Foodstuff - Pawns can auto fetch raw food if no meals, also will fetch for animal training.
+ * -for Drugs - Pawns can auto fetch drugs to fit a schedule.
+ * -for Ammo of each Gun that uses CombatExtended Ammo.  Created programattically so should automatically get new guns/ammo.
  */
- 
- /* Keep the following list up to date!  Try to avoid defining overlapping sets.  You will get a warning on startup if a very bad overlap occurs.
-  * Currently defined Generics:
-  * -for Meals - Pawns auto fetch a best food, generaly meals
-  * -for Raw Foodstuff - Pawns can auto fetch raw food if no meals, also will fetch for animal training.
-  * -for Drugs - Pawns can auto fetch drugs to fit a schedule.
-  * -for Ammo of each Gun that uses CombatExtended Ammo.  Created programattically so should automatically get new guns/ammo.
-  */
 namespace CombatExtended
 {
 	/// <summary>
@@ -46,9 +36,6 @@ namespace CombatExtended
 		internal static string dividingString = "CE_Generic_Divider".Translate();
 		internal bool isAmmo;
 		
-		// (ProfoundDarkness) overlaps and conflicts are better handled later on so disabled but could still prove useful.
-		// Having a key but a false value indicates that it's a perfect conflict.  True indicates imperfect conflict.  No key means no conflict.
-		//public readonly Dictionary<LoadoutGenericDef, bool> conflicts = new Dictionary<LoadoutGenericDef, bool>();
 		#endregion
 		
 		#region Constructors
@@ -77,8 +64,8 @@ namespace CombatExtended
 			generic.label = "CE_Generic_RawFood".Translate();
 			// Exclude drugs and corpses.  Also exclude any food worse than RawBad as in testing the pawns would not even pick it up for training.
 			generic._lambda = td => td.IsNutritionGivingIngestible && td.ingestible.preferability <= FoodPreferability.RawTasty && td.ingestible.HumanEdible && td.plant == null && !td.IsDrug && !td.IsCorpse;
-			//generic.defaultCount = Convert.ToInt32(Math.Floor(targetNutrition / everything.Where(td => generic.lambda(td)).Average(td => td.ingestible.nutrition)));
-			generic.defaultCount = 1;
+			generic.defaultCount = Convert.ToInt32(Math.Floor(targetNutrition / everything.Where(td => generic.lambda(td)).Average(td => td.ingestible.nutrition)));
+			//generic.defaultCount = 1;
 			generic.isBasic = true;
 			
 			defs.Add(generic);
@@ -86,6 +73,7 @@ namespace CombatExtended
 
 			generic = new LoadoutGenericDef();
 			generic.defName = "GenericDrugs";
+			generic.defaultCount = 3;
 			generic.description = "Generic Loadout for Drugs.  Intended for compatibility with pawns automatically picking up drugs in compliance with drug policies.";
 			generic.label = "CE_Generic_Drugs".Translate();
 			// not really sure what defaultCount should be so leaving unset.
@@ -114,68 +102,13 @@ namespace CombatExtended
 				generic.label = string.Format(ammoLabel, gun.LabelCap);
 				generic.itemString = gun.LabelCap;
 				generic.defaultCount = gun.GetCompProperties<CompProperties_AmmoUser>().magazineSize;
-				//Consider all ammos that the gun can fire, take the average.  Could also use the min or max...  //TODO: Decide if max or average is apt.
-				//generic.defaultCount = Convert.ToInt32(Math.Floor(DefDatabase<AmmoDef>.AllDefs
-				//                                                  .Where(ad => gun.GetCompProperties<CompProperties_AmmoUser>().ammoSet.ammoTypes.Contains(ad))
-				//                                                  .Average(ad => ad.defaultAmmoCount)));
 				generic.defaultCountType = LoadoutCountType.pickupDrop; // we want ammo to get picked up.
-				generic._lambda = td => td is AmmoDef && gun.GetCompProperties<CompProperties_AmmoUser>().ammoSet.ammoTypes.Contains(td);
+				//generic._lambda = td => td is AmmoDef && gun.GetCompProperties<CompProperties_AmmoUser>().ammoSet.ammoTypes.Contains(td);
+				generic._lambda = td => gun.GetCompProperties<CompProperties_AmmoUser>().ammoSet.ammoTypes.Any(al => al.ammo == td);
 				generic.isAmmo = true;
 				defs.Add(generic);
 				//Log.Message(string.Concat("CombatExtended :: LoadoutGenericDef :: ", generic.LabelCap, " list: ", string.Join(", ", DefDatabase<ThingDef>.AllDefs.Where(t => generic.lambda(t)).Select(t => t.label).ToArray())));
 			}
-			
-			/* // (ProfoundDarkness) The methodology I'm using for LoadoutSlots allows for duplicates and partial overlaps (technically) so this code is less useful.
-			// check for overlapping case and issue a warning if there is one... (yeah this is horribly inefficient but only happens once per game.)
-			// First iteration looks for a merge-able perfect conflict and merges them when found.
-			for (int i = 0; i <= defs.Count - 1; i++)
-			{
-				IEnumerable<ThingDef> a = everything.Where(t => defs[i].lambda(t));
-				for (int j = i+1; j <= defs.Count - 1; j++)
-				{
-					IEnumerable<ThingDef> b = everything.Where(t => defs[j].lambda(t));
-					IEnumerable<ThingDef> c = a.Intersect(b);
-					if (c.Any())
-					{
-						if (a.Count() == c.Count() && b.Count() == c.Count() && defs[i].isAmmo && defs[j].isAmmo) // perfect conflict in ammo, can merge...
-						{
-							defs[i].itemString = string.Concat(defs[i].itemString, dividingString, defs[j].itemString);
-							defs[i].label = string.Format(ammoLabel, defs[i].itemString);
-							defs[i].description = string.Format(ammoDescription, defs[i].itemString);
-							defs.RemoveAt(j);
-							j--;
-						}
-					}
-				}
-			}
-			
-			// this iteration marks conflicts that couldn't be merged and issues warnings.
-			for (int i = 0; i <= defs.Count - 1; i++)
-			{
-				IEnumerable<ThingDef> a = everything.Where(t => defs[i].lambda(t));
-				for (int j = i+1; j <= defs.Count - 1; j++)
-				{
-					IEnumerable<ThingDef> b = everything.Where(t => defs[j].lambda(t));
-					IEnumerable<ThingDef> c = a.Intersect(b);
-					if (c.Any())
-					{
-						if (a.Count() != c.Count() && b.Count() != c.Count())
-						{
-							defs[i].conflicts.Add(defs[j], true);
-							defs[j].conflicts.Add(defs[i], true);
-							Log.Warning(string.Concat("CombatExtended :: LoadoutGenericDef :: ", defs[i].LabelCap, " and ", defs[j].LabelCap, 
-								" share some members but are not identical and thus may cause problems with loadouts.  The following items are contained in both: ",
-								string.Join(", ", c.Select(td => td.defName).ToArray())));
-						} else {
-							defs[i].conflicts.Add(defs[j], false);
-							defs[j].conflicts.Add(defs[i], false);
-							Log.Warning(string.Concat("CombatExtended :: LoadoutGenericDef :: ", defs[i].LabelCap, " and ", defs[j].LabelCap,
-							                          " are a perfect conflict.  At the moment the code isn't aware of dealing with these but it can be if an issue is filed."));
-						}
-					}
-				}
-			}
-			*/
 			
 			DefDatabase<LoadoutGenericDef>.Add(defs);
 		}

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_UnloadYourInventory.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_UnloadYourInventory.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using RimWorld;
+using Verse;
+using Verse.AI;
+
+namespace CombatExtended
+{
+	/// <summary>
+	/// This class gets used when a Pawn returning from a Caravan is unloading it's own inventory.
+	/// Class is mostly copied from Rimworld with adjustments to have it ask components of CombatExtended for what and how much to drop from the player's own invetory.
+	/// </summary>
+	public class JobDriver_UnloadYourInventory : JobDriver
+	{
+		private const TargetIndex ItemToHaulInd = TargetIndex.A;
+
+		private const TargetIndex StoreCellInd = TargetIndex.B;
+
+		private const int UnloadDuration = 10;
+		
+		private int amountToDrop;
+
+		[DebuggerHidden]
+		protected override IEnumerable<Toil> MakeNewToils()
+		{
+			yield return Toils_General.Wait(10);
+			yield return new Toil
+			{
+				initAction = delegate
+				{
+					Thing dropThing;
+					int dropCount;
+					if (!this.pawn.inventory.UnloadEverything || !this.pawn.GetAnythingForDrop(out dropThing, out dropCount))
+					{
+						this.EndJobWith(JobCondition.Succeeded);
+					}
+					else
+					{
+						IntVec3 c;
+						if (!StoreUtility.TryFindStoreCellNearColonyDesperate(dropThing, this.pawn, out c))
+						{
+							this.pawn.inventory.innerContainer.TryDrop(dropThing, this.pawn.Position, this.pawn.Map, ThingPlaceMode.Near, dropCount, out dropThing);
+							this.EndJobWith(JobCondition.Succeeded);
+						}
+						else
+						{
+							this.CurJob.SetTarget(TargetIndex.A, dropThing);
+							this.CurJob.SetTarget(TargetIndex.B, c);
+							amountToDrop = dropCount;
+						}
+					}
+				}
+			};
+			yield return Toils_Reserve.Reserve(TargetIndex.B, 1);
+			yield return Toils_Goto.GotoCell(TargetIndex.B, PathEndMode.Touch);
+			yield return new Toil
+			{
+				initAction = delegate
+				{
+					Thing thing = this.CurJob.GetTarget(TargetIndex.A).Thing;
+					if (thing == null || !this.pawn.inventory.innerContainer.Contains(thing))
+					{
+						this.EndJobWith(JobCondition.Incompletable);
+						return;
+					}
+					if (!this.pawn.health.capacities.CapableOf(PawnCapacityDefOf.Manipulation) || !thing.def.EverStoreable)
+					{
+						this.pawn.inventory.innerContainer.TryDrop(thing, this.pawn.Position, this.pawn.Map, ThingPlaceMode.Near, amountToDrop, out thing);
+						this.EndJobWith(JobCondition.Succeeded);
+					}
+					else
+					{
+						this.pawn.inventory.innerContainer.TransferToContainer(thing, this.pawn.carryTracker.innerContainer, amountToDrop, out thing);
+						this.CurJob.count = amountToDrop;
+						this.CurJob.SetTarget(TargetIndex.A, thing);
+					}
+					thing.SetForbidden(false, false);
+					
+					if (!this.pawn.HasAnythingForDrop())
+					{
+						this.pawn.inventory.UnloadEverything = false;
+					}
+				}
+			};
+			Toil carryToCell = Toils_Haul.CarryHauledThingToCell(TargetIndex.B);
+			yield return carryToCell;
+			yield return Toils_Haul.PlaceHauledThingInCell(TargetIndex.B, carryToCell, true);
+		}
+	}
+}

--- a/Source/CombatExtended/CombatExtended/Loadouts/HoldRecord.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/HoldRecord.cs
@@ -7,15 +7,15 @@ namespace CombatExtended
 	/// HoldRecord stores key information for an individual element of HoldTracker.
 	/// </summary>
 	/// <remarks>Wow this is looking a lot like a LoadoutSlot now...  Remembering by Thing doesn't work out.</remarks>
-	public class HoldRecord
+	public class HoldRecord : IExposable
 	{
 		#region Fields
 		const int INVALIDTICKS = GenDate.TicksPerDay;
 		
-		private ThingDef def;
+		private ThingDef _def;
 		public int count;
 		public bool pickedUp;
-		private readonly int tickJobIssued;
+		private int _tickJobIssued;
 		
 		#endregion
 		
@@ -27,10 +27,17 @@ namespace CombatExtended
 		/// <param name="newCount">How much to hold onto.</param>
 		public HoldRecord(ThingDef newThingDef, int newCount)
 		{
-			def = newThingDef;
+			_def = newThingDef;
 			count = newCount;
 			pickedUp = false;
-			tickJobIssued = GenTicks.TicksAbs;
+			_tickJobIssued = GenTicks.TicksAbs;
+		}
+
+		/// <summary>
+		/// Default Constructor.  Used by Rimworld LoadSave and shouldn't be used by any other code.
+		/// </summary>
+		public HoldRecord()
+		{
 		}
 		#endregion
 		
@@ -38,9 +45,9 @@ namespace CombatExtended
 		/// <summary>
 		/// If the item hasn't been picked up is it still valid to remember?
 		/// </summary>
-		public bool isTimeValid	{ get { return !pickedUp && ((GenTicks.TicksAbs - tickJobIssued) <= INVALIDTICKS); } }
+		public bool isTimeValid	{ get { return !pickedUp && ((GenTicks.TicksAbs - _tickJobIssued) <= INVALIDTICKS); } }
 		
-		public ThingDef thingDef { get { return this.def; } }
+		public ThingDef thingDef { get { return this._def; } }
 		
 		#endregion
 		
@@ -52,9 +59,22 @@ namespace CombatExtended
 		public override string ToString()
 		{
 			return string.Concat("HoldRecord for ", thingDef, " of count ", count, " which has", (!pickedUp ? "n't" : ""), " been picked up",
-			                           (!pickedUp ? string.Concat(" with a job issue time of ", (GenTicks.TicksAbs - tickJobIssued),
-			                                                      " ago and will go invalid in ", (GenTicks.TicksAbs + INVALIDTICKS - tickJobIssued)) : "."));
+			                           (!pickedUp ? string.Concat(" with a job issue time of ", (GenTicks.TicksAbs - _tickJobIssued),
+			                                                      " ago and will go invalid in ", (GenTicks.TicksAbs + INVALIDTICKS - _tickJobIssued)) : "."));
 		}
+		#endregion
+
+		#region IExposable implementation
+
+		public void ExposeData()
+		{
+			Scribe_Defs.LookDef(ref _def, "ThingDef");
+			Scribe_Values.LookValue(ref count, "count");
+			Scribe_Values.LookValue(ref pickedUp, "pickedUp");
+			if (!pickedUp)
+				Scribe_Values.LookValue(ref _tickJobIssued, "tickOfPickupJob");
+		}
+
 		#endregion
 	}
 }

--- a/Source/CombatExtended/CombatExtended/Loadouts/HoldTrackerAssignment.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/HoldTrackerAssignment.cs
@@ -1,0 +1,41 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Verse;
+
+namespace CombatExtended
+{
+    public class HoldTrackerAssignment : IExposable
+    {
+        #region Fields
+
+        internal Pawn pawn;
+        internal List<HoldRecord> recs;
+
+        #endregion Fields
+
+        public bool Valid
+        {
+            get
+            {
+                return ((pawn != null) && (recs != null));
+            }
+        }
+
+        #region Methods
+
+        public void ExposeData()
+        {
+            Scribe_References.LookReference( ref pawn, "pawn" );
+            Scribe_Collections.LookList( ref recs, "holdRecords" );
+
+#if DEBUG
+Log.Message( Scribe.mode + ", pawn: " + ( pawn == null ? "NULL" : pawn.NameStringShort ) + ", holdRecords: " + ( recs == null ? "NULL" : string.Join(", ", recs.Select(hr => hr.thingDef.ToString()).ToArray()) ) );
+#endif
+        }
+
+        #endregion Methods
+    }
+}

--- a/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Loadout.cs
@@ -107,7 +107,9 @@ namespace CombatExtended
         	Loadout dest = new Loadout(newName);
         	dest.defaultLoadout = source.defaultLoadout;
         	dest.canBeDeleted = source.canBeDeleted;
-        	dest.Slots.RemoveAll(s => true); // since a new Loadout has some default slots, drop them during the copy.
+        	dest._slots = new List<LoadoutSlot>();
+        	foreach(LoadoutSlot slot in source.Slots)
+        		dest.AddSlot(slot.Copy());
         	return dest;
         }
         

--- a/Source/CombatExtended/CombatExtended/Loadouts/LoadoutSlot.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/LoadoutSlot.cs
@@ -24,6 +24,7 @@ namespace CombatExtended
         private const int _defaultCount = 1;
         private int _count;
         private Def _def;
+        private Type _type; // to help with save/load.
         private LoadoutCountType _countType = LoadoutCountType.pickupDrop; // default mode for new loadout slots.
 
         #endregion Fields
@@ -37,6 +38,7 @@ namespace CombatExtended
         /// <param name="count">int indicating number of items of ThingDef to store.</param>
         public LoadoutSlot( ThingDef def, int count = 1 )
         {
+        	_type = typeof(ThingDef);
             _count = count;
             _def = def;
 
@@ -54,6 +56,7 @@ namespace CombatExtended
         /// <param name="count">Optional int how many should be picked up. If left blank then the default value from the LoadoutGenericDef is used.</param>
         public LoadoutSlot(LoadoutGenericDef def, int count = 0)
         {
+        	_type = typeof(LoadoutGenericDef);
         	if ( count < 1)
         		count = def.defaultCount;
         	
@@ -101,7 +104,16 @@ namespace CombatExtended
         public void ExposeData()
         {
             Scribe_Values.LookValue( ref _count, "count", _defaultCount );
-            Scribe_Defs.LookDef( ref _def, "def" );
+            Scribe_Values.LookValue(ref _type, "DefType");
+            ThingDef td = thingDef;
+            LoadoutGenericDef gd = genericDef;
+            if (_type == typeof(ThingDef))
+            	Scribe_Defs.LookDef(ref td, "def");
+            if (_type == typeof(LoadoutGenericDef))
+            	Scribe_Defs.LookDef(ref gd, "def");
+            if (Scribe.mode == LoadSaveMode.LoadingVars)
+            	_def = (_type == typeof(ThingDef) ? td as Def : gd as Def);
+            //Scribe_Defs.LookDef( ref _def, "def" );
             
             // when saving _def is defined.  When loading _def should have gotten it's contents by now.
             if (genericDef != null)

--- a/Source/CombatExtended/Harmony/Harmony-HediffComp_TendDuration_CompTended_Patch.cs
+++ b/Source/CombatExtended/Harmony/Harmony-HediffComp_TendDuration_CompTended_Patch.cs
@@ -1,6 +1,5 @@
-﻿//using System.Collections;
+﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Reflection.Emit;
 using Harmony;
 using Verse;
@@ -11,13 +10,13 @@ namespace CombatExtended.Harmony
 	 * Specifically the (decompiled) line this.tendQuality = Mathf.Clamp01(quality + Rand.Range(-0.25f, 0.25f));
 	 * More specifically the value -0.25f and 0.25f
 	 */ 
-	[HarmonyPatch(typeof(HediffComp_TendDuration))]
-	[HarmonyPatch("CompTended")]
-	static class HediffComp_TendDuration_Patch
+	[HarmonyPatch(typeof(HediffComp_TendDuration))] // Target class for patching, generally required.
+	[HarmonyPatch("CompTended")] // Target method for patching, generally required.
+	[HarmonyPatch(new Type[] {typeof(float), typeof(int)})] // Target method signature (arguments), not generally required if there is only one method with the target name in the target class.
+	static class HediffComp_TendDuration_CompTended_Patch
 	{
-		
-		[HarmonyTranspiler]
-		static IEnumerable<CodeInstruction> CompTended_Patch(IEnumerable<CodeInstruction> instructions)
+		// can name the method something else but then requires the attribute [HarmonyTranspiler]
+		static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
 		{
 			int countReplace = 0;
 			foreach (CodeInstruction instruction in instructions)

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -12,7 +12,7 @@ namespace CombatRealism.Harmony
 		static HarmonyBase()
 		{
 			// Unremark the following when developing new Harmony patches.  The file "harmony.log.txt" on your desktop and is always appended.  Will cause ALL patches to be debugged.
-			//HarmonyInstance.DEBUG = true;
+			HarmonyInstance.DEBUG = true;
 			
 			// The following line will cause all properly formatted and annotated classes to patch the target code.
 			instance.PatchAll(Assembly.GetExecutingAssembly());

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -12,7 +12,7 @@ namespace CombatRealism.Harmony
 		static HarmonyBase()
 		{
 			// Unremark the following when developing new Harmony patches.  The file "harmony.log.txt" on your desktop and is always appended.  Will cause ALL patches to be debugged.
-			HarmonyInstance.DEBUG = true;
+			//HarmonyInstance.DEBUG = true;
 			
 			// The following line will cause all properly formatted and annotated classes to patch the target code.
 			instance.PatchAll(Assembly.GetExecutingAssembly());


### PR DESCRIPTION
JobDriver_UnloadYourInventory:
-New JobDriver_UnloadYourInventory which asks HoldTracker concept about what should be dropped if anything.  This should prevent Pawn's inventory items which satisfy loadouts from being dropped.
-Disabled (but not removed) JobDriver_UnloadInvetory.  I don't know but I think this JobDriver was created for Issue #70 and if so was the wrong target.  NOTE: There may be some new methods that were added for this JobDriver.

Loadouts:
-Loadouts not saving/loading properly.
-Moved some of HoldTracker's methods into LoadoutManager class as that gets instantiated which is necessary for saving.
-Altered HoldTracker's structure to be a Dictionary<Pawn, List<HoldRecord>> instead of Dictionary<Pawn, Dictionary<ThingDef, HoldRecord>> to make it a bit easier to save.
-Modeled HoldTracker saving off of LoadoutManager saving (dictionary to list and back again).
-Altered segments of code which had used Dictionary<ThingDef, HoldTracker> to work with List<HoldRecord> as well as logic where apt.
-Tried to speed up JobGiver_UpdateLoadout by skipping to the next LoadoutSlot sooner.  Also some alterations there in relation to above/bug fixing.
-Renamed HoldTracker class to Utility_HoldTracker to fit with the theme shift of moving some elements of the concept to LoadoutManager.