### PR TITLE
All CEVerb weapons that use ammo should do a reload before warmup.

### DIFF
--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -271,6 +271,7 @@
     <Compile Include="Detours\Detours_WorkGiver_InteractAnimal.cs" />
     <Compile Include="Harmony\Harmony-GenRadial_RadialPatternCount_Patch.cs" />
     <Compile Include="Harmony\Harmony-HediffComp_TendDuration_CompTended_Patch.cs" />
+    <Compile Include="Harmony\Harmony-Verb_TryStartCastOn_Patch.cs" />
     <Compile Include="Harmony\HarmonyBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CombatExtended\Verbs\Verb_ShootCE.cs" />

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -337,5 +337,7 @@ namespace CombatExtended
                 TryUpdateInventory(tracker.pawn);
             }
         }
+        
+        #endregion
     }
 }

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -94,7 +94,7 @@ namespace CombatExtended
 						{
 							if (listing.ContainsKey(curSlot.thingDef))
 							{
-								int amount = listing[curSlot.thingDef].value >= wantCount ? wantCount : wantCount - listing[curSlot.thingDef].value;
+								int amount = listing[curSlot.thingDef].value >= wantCount ? wantCount : listing[curSlot.thingDef].value;
 								listing[curSlot.thingDef].value -= amount;
 								wantCount -= amount;
 								if (listing[curSlot.thingDef].value <= 0)
@@ -107,7 +107,7 @@ namespace CombatExtended
 							int amount;
 							foreach (ThingDef def in listing.Keys.Where(td => curSlot.genericDef.lambda(td)))
 							{
-								amount = listing[def].value >= wantCount ? wantCount : wantCount - listing[def].value;
+								amount = listing[def].value >= wantCount ? wantCount : listing[def].value;
 								listing[def].value -= amount;
 								wantCount -= amount;
 								if (listing[def].value <= 0)
@@ -281,13 +281,11 @@ namespace CombatExtended
 	                    {
 	                        return new Job(JobDefOf.Equip, closestThing);
 	                    }
-	                    // Take items into inventory if needed
-	                    int numContained = inventory.container.TotalStackCountOfDef(closestThing.def);
-	                    return new Job(JobDefOf.TakeInventory, closestThing) { count = Mathf.Min(closestThing.stackCount, count - numContained) };
+	                    return new Job(JobDefOf.TakeInventory, closestThing) { count = Mathf.Min(closestThing.stackCount, count) };
 	                } else
 	                {
 	                	return new Job(CE_JobDefOf.TakeFromOther, closestThing, carriedBy, doEquip ? pawn : null) {
-	                		count = doEquip ? 1 : Mathf.Min(closestThing.stackCount, count - inventory.container.TotalStackCountOfDef(closestThing.def))
+	                		count = doEquip ? 1 : Mathf.Min(closestThing.stackCount, count)
 	                	};
 	                }
                 }

--- a/Source/CombatExtended/Harmony/Harmony-Verb_TryStartCastOn_Patch.cs
+++ b/Source/CombatExtended/Harmony/Harmony-Verb_TryStartCastOn_Patch.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using Harmony;
+using Verse;
+using Verse.AI;
+
+
+
+/*
+ * Initial notes:
+ * Trying to find a general solution to the reload after warmup problem (want reload before warmup).
+ * Followed several paths and ended up with Verb.TryStartCastOn.
+ * That logic has the bit where the pawn gets put into the warmup stance.  Now need to figure out how to insert a path change so that
+ *  if a pawn is out of ammo they try to reload and if that job fails they should fail from the TryStartCastOn...
+ */
+ 
+ namespace CombatExtended.Harmony
+ {
+ 	[HarmonyPatch(typeof(Verb))]
+ 	[HarmonyPatch("TryStartCastOn")]
+ 	[HarmonyPatch(new Type[] { typeof(LocalTargetInfo), typeof(bool), typeof(bool) } )]
+	static class Verb_TryStartCastOn_Patch
+	{
+		
+		[HarmonyTranspiler]
+		static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+		{
+			// targetting after the lines
+			// if (!this.TryFindShootLineFromTo(this.caster.Position, castTarg, out line))
+        	// {
+            // 		return false;
+            // }
+			
+            bool foundCall = false;
+            bool foundBranch = false;
+            bool donePatch = false;
+            object branchLabel = null;
+            
+            foreach (CodeInstruction instruction in instructions)
+            {
+            	if (foundBranch && !donePatch)
+            	{
+            		// this is where we want to insert our call and branch if it failed.
+            		CodeInstruction ldArg = new CodeInstruction(OpCodes.Ldarg_0);
+            		CodeInstruction call = new CodeInstruction(OpCodes.Call, typeof(Verb_TryStartCastOn_Patch).GetMethod("CheckReload", AccessTools.all));
+            		
+            		//CodeInstruction branch = new CodeInstruction(OpCodes.Brfalse, );
+            		yield return ldArg;
+            		yield return call;
+            		yield return new CodeInstruction(OpCodes.Brfalse, branchLabel);
+            		donePatch = true;
+            	}
+            	
+            	if (foundCall && !foundBranch && instruction.opcode == OpCodes.Brfalse)
+            	{
+            		foundBranch = true;
+            		branchLabel = instruction.operand;
+            		Log.Message(instruction.operand.ToString());
+            	}
+            	
+            	if (!foundCall && instruction.opcode == OpCodes.Call && ((MethodInfo)instruction.operand).Name.Contains("TryFindShootLineFromTo"))
+            		foundCall = true;
+            	
+            	yield return instruction;
+            }
+		}
+		
+		// Functions like a prefix.  If this has something to do return false. if nothing to do return true.
+		static bool CheckReload(Verb __instance)
+		{
+			if (!(__instance is Verb_ShootCE || __instance is Verb_ShootCEOneUse))
+				return true; // no work to do as the verb isn't the right kind.
+			
+			CompAmmoUser gun = __instance.ownerEquipment.TryGetComp<CompAmmoUser>();
+			if (gun == null || !gun.hasMagazine || gun.curMagCount > 0)
+				return true; // gun isn't an ammo user that stores ammo internally or isn't out of bullets.
+			
+			// we got work to do at this point.
+			// Try starting the reload job.
+			gun.TryStartReload();
+			
+			return false;
+		}
+	}
+ }

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -12,7 +12,7 @@ namespace CombatExtended.Harmony
 		static HarmonyBase()
 		{
 			// Unremark the following when developing new Harmony patches.  The file "harmony.log.txt" on your desktop and is always appended.  Will cause ALL patches to be debugged.
-			//HarmonyInstance.DEBUG = true;
+			HarmonyInstance.DEBUG = true;
 			
 			// The following line will cause all properly formatted and annotated classes to patch the target code.
 			instance.PatchAll(Assembly.GetExecutingAssembly());

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -12,7 +12,7 @@ namespace CombatExtended.Harmony
 		static HarmonyBase()
 		{
 			// Unremark the following when developing new Harmony patches.  The file "harmony.log.txt" on your desktop and is always appended.  Will cause ALL patches to be debugged.
-			HarmonyInstance.DEBUG = true;
+			//HarmonyInstance.DEBUG = true;
 			
 			// The following line will cause all properly formatted and annotated classes to patch the target code.
 			instance.PatchAll(Assembly.GetExecutingAssembly());


### PR DESCRIPTION
Related to issue #29.

Took some time to find the interesting point where a pawn switches from trying to shoot to the warmup but finally found it.  From there did a Harmony Hybrid Infixed Prefix (functions like a Prefix but is Infixed).

The infix patch passes the instance verb into a needs reload check.  If the check returns false that means there was work to do (yeah, backwards) and the pawn shouldn't enter the warmup stance.  If true then either it wasn't a gun with ammo or it didn't need reload, the pawn enters the reload stance.

Thanks to whoever created/maintained the CompAmmoUser.TryStartReload() as I had no idea how to get turrets reloading and that just handled it for me.

Also includes some side fixes related to loadouts.