### PR TITLE
Pawn auto firing issues

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_CheckReload.cs
@@ -14,7 +14,7 @@ namespace CombatExtended
 		#region Fields
 		
 		// lower priority = less likely to be done.  Need to give this a priority below JobGiver_Update Loadout's high priority setting.
-		const float reloadPriority = 9.1f; // 9.2 is high priority, 3 is lower priority.
+		const float reloadPriority = 9.1f; // in JobGiver_UpdateLoadout, 9.2 is high priority, 3 is lower priority.
 		
 		#endregion Fields
 		
@@ -37,7 +37,7 @@ namespace CombatExtended
 			ThingWithComps ignore1;
 			AmmoDef ignore2;
 			if (!pawn.Drafted && DoReloadCheck(pawn, out ignore1, out ignore2))
-				return 9.1f;
+				return reloadPriority;
             
 			return 0.0f;
 		}
@@ -107,9 +107,9 @@ namespace CombatExtended
 			
 			if ((tmpComp = pawn.equipment?.Primary?.TryGetComp<CompAmmoUser>()) != null && tmpComp.hasMagazine && tmpComp.useAmmo)
 				guns.Add(pawn.equipment.Primary);
-			
-			// CompInventory doesn't track equipment and it's desired to check the pawn's equipped weapon before inventory items so need to copy stuff from Inventory Cache.
-			guns.AddRange(inventory.rangedWeaponList.Where(t => t.GetComp<CompAmmoUser>().hasMagazine && t.GetComp<CompAmmoUser>().useAmmo));
+
+            // CompInventory doesn't track equipment and it's desired to check the pawn's equipped weapon before inventory items so need to copy stuff from Inventory Cache.
+            guns.AddRange(inventory.rangedWeaponList.Where(t => t.TryGetComp<CompAmmoUser>() != null && t.GetComp<CompAmmoUser>().hasMagazine && t.GetComp<CompAmmoUser>().useAmmo));
 			
 			if (guns.NullOrEmpty())
 				return false; // There isn't any work to do since the pawn doesn't have any ammo using guns.

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -375,6 +375,7 @@ namespace CombatExtended
                     {
                         newCover = coverAtCell;
                     }
+                    checkedCells.Add(cell);
                 }
             }
             cover = newCover;

--- a/Source/CombatExtended/Harmony/Harmony-AttackTargetFinder_BestAttackTarget_Patch.cs
+++ b/Source/CombatExtended/Harmony/Harmony-AttackTargetFinder_BestAttackTarget_Patch.cs
@@ -45,11 +45,11 @@ namespace CombatExtended.Harmony
 			List<MethodInfo> empty = new List<MethodInfo>();  // doesn't matter...
 			List<MethodInfo> transpilers = new List<MethodInfo>(); // puts the transpiler into the format expected by patcher.
 			transpilers.Add(patchMethod);
-			
-			// due to how this patching takes place need to make sure debug is set before running the copy or else no debug output.
-			//HarmonyInstance.DEBUG = true;
-			// get the patched original method (after the below line the original code will have the new stuff we want added to it).
-			Patched_ClosestThingTarget_Global = MethodPatcher.CreatePatchedMethod(oldMethod, empty, empty, transpilers);
+
+            // due to how this patching takes place need to make sure debug is set before running the copy or else no debug output.
+            //HarmonyInstance.DEBUG = true;
+            // get the patched original method (after the below line the original code will have the new stuff we want added to it).
+            Patched_ClosestThingTarget_Global = MethodPatcher.CreatePatchedMethod(oldMethod, empty, empty, transpilers);
 			if (Patched_ClosestThingTarget_Global == null) throw new MissingMethodException("Cannot create dynamic replacement for " + oldMethod);
 			
 			// get the new method to instanciate it's IL.  Otherwise the memory call and WriteJump don't have something to work with...
@@ -85,6 +85,7 @@ namespace CombatExtended.Harmony
 			bool foundBGT = false;
 			bool foundInsertion = false;
 			int instructionCount = 0;
+
 			
 			// this is the label we will use to emulate a 'continue' in a 'foreach'
 			object continueLabel = null;
@@ -138,7 +139,8 @@ namespace CombatExtended.Harmony
 				{
 					if (!patched)
 					{
-						if (instructionCount <= 0)
+                        // (ProfoundDarkness) used to use instructionCount but that was not quite right for some reason...
+						if (instruction.opcode == OpCodes.Ldstr && (instruction.operand as string) == "validator")
 						{
 							// Roughyly equivelent line of code: if (!CanShootTarget(center, thing)) continue;
 							// patched after the line float lengthHorizontalSquared = (center - thing.Position).LengthHorizontalSquared;
@@ -182,12 +184,12 @@ namespace CombatExtended.Harmony
 		{
 			//Log.Message(string.Concat(logPrefix, "Shooter at ", shooterPosition.ToString(), " is considering target ", target.LabelCap, " at ", target.Position.ToString()));
 			Thing cover;
-			if (!Verb_LaunchProjectileCE.GetPartialCoverBetween(target.Map, target.Position.ToVector3Shifted(), shooterPosition.ToVector3Shifted(), out cover))
+            if (!Verb_LaunchProjectileCE.GetPartialCoverBetween(target.Map, shooterPosition.ToVector3Shifted(), target.Position.ToVector3Shifted(), out cover))
 			{
 				//Log.Message(string.Concat(logPrefix, "Result: Can Shoot."));
 				return true;
 			}
-			//Log.Message(string.Concat(logPrefix, "Result: Cannot shoot."));
+            //Log.Message(string.Concat(logPrefix, "Result: Cannot shoot."));
 			return false;
 		}
 	}


### PR DESCRIPTION
Attempt to fix various issues related to drafted pawns auto-firing.
Issue 1: The code that inserted the call in IL was inserting it in the wrong place, breaking the key logic of the function.

Issue 2: The call to Verb_LaunchProjectileCE.GetPartialCoverBetween() had the 2nd and 3rd arguments backwards from the correct order, so was checking if the shooter had cover and if so the target was invalid (heh).

Issue 3: An older bug in GetPartialCoverBetween where the checkedCells list wasn't being updated with the cells which had been checked potentially reducing performance in all situations related to shooting.