### PR TITLE
Fixed a save/load issue (red text) on turrets, also job failure.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
@@ -52,6 +52,9 @@ namespace CombatExtended
             else
                 this.FailOnDestroyedNullOrForbidden(TargetIndex.A);
 
+            // Reserve the turret
+            yield return Toils_Reserve.Reserve(TargetIndex.A, 1);
+
             if (compReloader.useAmmo)
             {
                 // Perform ammo system specific activities, failure condition and hauling
@@ -66,7 +69,6 @@ namespace CombatExtended
                 }
 
                 // Haul ammo
-                yield return Toils_Reserve.Reserve(TargetIndex.A, 1);
                 yield return Toils_Reserve.Reserve(TargetIndex.B, 1);
                 yield return Toils_Goto.GotoCell(ammo.Position, PathEndMode.ClosestTouch);
                 yield return Toils_Haul.StartCarryThing(TargetIndex.B);
@@ -75,7 +77,6 @@ namespace CombatExtended
             } else
             {
                 // If ammo system is turned off we just need to go to the turret.
-                yield return Toils_Reserve.Reserve(TargetIndex.A, 1);
                 yield return Toils_Goto.GotoCell(turret.Position, PathEndMode.ClosestTouch);
             }
 

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
@@ -8,62 +8,98 @@ namespace CombatExtended
 {
     public class JobDriver_ReloadTurret : JobDriver
     {
+        private Building_TurretGunCE _turret;
+        private Building_TurretGunCE turret
+        {
+            get
+            {
+                if (_turret == null)
+                    _turret = TargetThingA as Building_TurretGunCE;
+                return _turret;
+            }
+        }
+
+        private AmmoThing _ammo;
+        private AmmoThing ammo
+        {
+            get
+            {
+                if (_ammo == null)
+                    _ammo = TargetThingB as AmmoThing;
+                return _ammo;
+            }
+        }
+
         private CompAmmoUser _compReloader;
         private CompAmmoUser compReloader
         {
             get
             {
                 if (_compReloader == null)
-                {
-                    Building_TurretGunCE turret = TargetThingA as Building_TurretGunCE;
-                    if (turret != null)
-                    {
-                        _compReloader = turret.compAmmo;
-                    }
-                }
+                    _compReloader = turret.compAmmo; // assumes turret has been error checked already...
                 return _compReloader;
             }
         }
 
+        private string errorBase { get { return this.GetType().Assembly.GetName().Name + " :: " + this.GetType().Name + " :: "; } }
+
         protected override IEnumerable<Toil> MakeNewToils()
         {
-           	if (compReloader.turret == null)
-				throw new System.ArgumentException("JobDriver_ReloadTurret :: compReloader.turret is null.  A turret is required for this job.");
-           	
-        	compReloader.turret.isReloading = true;
-                
-            if (compReloader.Props.throwMote)
-                MoteMaker.ThrowText(compReloader.turret.Position.ToVector3Shifted(), Find.VisibleMap, "CE_ReloadingMote".Translate());
+            // order of these errors matters some...
+            if (turret == null)
+            {
+                Log.Error(string.Concat(errorBase, "TargetThingA isn't a Building_TurretGunCE"));
+                yield return null;
+            }
+           	if (compReloader == null)
+            {
+                Log.Error(string.Concat(errorBase, "TargetThingA (Building_TurretGunCE) is missing it's CompAmmoUser."));
+                yield return null;
+            }
+            if (ammo == null)
+            {
+                Log.Error(string.Concat(errorBase, "TargetThingB is either null or not an AmmoThing."));
+                yield return null;
+            }
+
+            if (pawn.Faction != Faction.OfPlayer)
+                this.FailOnDestroyedOrNull(TargetIndex.A);
+            else
+                this.FailOnDestroyedNullOrForbidden(TargetIndex.A);
+
+            // get the turret's interaction cell and set it to TargetIndex.C
             
+            turret.isReloading = true;
+
             if (compReloader.useAmmo)
             {
                 if (pawn.Faction != Faction.OfPlayer)
                 {
-                    TargetThingB.SetForbidden(false, false);
-                    this.FailOnDestroyedOrNull(TargetIndex.A);
+                    ammo.SetForbidden(false, false);
                     this.FailOnDestroyedOrNull(TargetIndex.B);
                 }
                 else
                 {
-                    this.FailOnDestroyedNullOrForbidden(TargetIndex.A);
                     this.FailOnDestroyedNullOrForbidden(TargetIndex.B);
                 }
 
                 // Haul ammo
                 yield return Toils_Reserve.Reserve(TargetIndex.A, 1);
                 yield return Toils_Reserve.Reserve(TargetIndex.B, 1);
-                yield return Toils_Goto.GotoThing(TargetIndex.B, PathEndMode.ClosestTouch);
+                yield return Toils_Goto.GotoCell(ammo.Position, PathEndMode.ClosestTouch);
                 yield return Toils_Haul.StartCarryThing(TargetIndex.B);
-                yield return Toils_Goto.GotoThing(TargetIndex.A, PathEndMode.ClosestTouch);
+                yield return Toils_Goto.GotoCell(turret.Position, PathEndMode.ClosestTouch);
                 yield return Toils_Haul.PlaceHauledThingInCell(TargetIndex.A, null, false);
             }
 
             // Wait in place
-            Toil waitToil = new Toil();
+            Toil waitToil = new Toil() { actor = pawn };
             waitToil.initAction = delegate
             {
                 waitToil.actor.pather.StopDead();
-                compReloader.TryStartReload();
+                if (compReloader.Props.throwMote)
+                    MoteMaker.ThrowText(turret.Position.ToVector3Shifted(), Find.VisibleMap, "CE_ReloadingMote".Translate());
+                compReloader.TryUnload();
             };
             waitToil.defaultCompleteMode = ToilCompleteMode.Delay;
             waitToil.defaultDuration = Mathf.CeilToInt(compReloader.Props.reloadTicks / pawn.GetStatValue(CE_StatDefOf.ReloadSpeed));
@@ -74,11 +110,7 @@ namespace CombatExtended
             reloadToil.defaultCompleteMode = ToilCompleteMode.Instant;
             reloadToil.initAction = delegate
             {
-                Building_TurretGunCE turret = TargetThingA as Building_TurretGunCE;
-                if (compReloader != null && turret.compAmmo != null)
-                {
-                    compReloader.LoadAmmo(TargetThingB);
-                }
+                compReloader.LoadAmmo(ammo);
             };
             if (compReloader.useAmmo) reloadToil.EndOnDespawnedOrNull(TargetIndex.B);
             yield return reloadToil;

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
@@ -66,6 +66,7 @@ namespace CombatExtended
                 }
 
                 // Haul ammo
+                yield return Toils_Reserve.Reserve(TargetIndex.A, 1);
                 yield return Toils_Reserve.Reserve(TargetIndex.B, 1);
                 yield return Toils_Goto.GotoCell(ammo.Position, PathEndMode.ClosestTouch);
                 yield return Toils_Haul.StartCarryThing(TargetIndex.B);


### PR DESCRIPTION
There was some red error text on save load related to turrets, fixed.

Took a fair bit of back and forth with NIA but also fixed the issue with pawns dropping out of their job when reloading a turret (basically while going to the ammo to pick it up or when returning to the turret with the ammo in hand).

Also re-positioned the reload mote for after the pawn returns to the turret.

Some other logic changes due to the error checking that is being done earlier on.