### PR TITLE
Tweaked HoldTracker user interaction.  "forced" display and clear btn.

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -56,6 +56,7 @@
   <CE_DropThingHaul>Drop and haul</CE_DropThingHaul>
   <CE_Eat>Consume</CE_Eat>
   <CE_HoldTrackerForget>Stop Holding</CE_HoldTrackerForget>
+  <CE_ForcedHold>Forced Holding</CE_ForcedHold>
 
   <!-- Medical -->
   <CE_Stabilize>Stabilize</CE_Stabilize>

--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -231,7 +231,8 @@ namespace CombatExtended
             GUI.color = _thingLabelColor;
             Rect thingLabelRect = new Rect(_thingLeftX, y, rect.width - _thingLeftX, _thingRowHeight);
             string thingLabel = thing.LabelCap;
-            if (thing is Apparel && SelPawnForGear.outfits != null && SelPawnForGear.outfits.forcedHandler.IsForced((Apparel)thing))
+            if ((thing is Apparel && SelPawnForGear.outfits != null && SelPawnForGear.outfits.forcedHandler.IsForced((Apparel)thing))
+                || (SelPawnForGear.inventory != null && SelPawnForGear.HoldTrackerIsHeld(thing)))
             {
                 thingLabel = thingLabel + ", " + "ApparelForcedLower".Translate();
             }

--- a/Source/CombatExtended/CombatExtended/Loadouts/MainTabWindow_OutfitsAndLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/MainTabWindow_OutfitsAndLoadouts.cs
@@ -194,13 +194,17 @@ namespace CombatExtended
                                          rowRect.height);
             Rect labelLoadoutRect = new Rect(loadoutRect.xMin,
                                               loadoutRect.yMin,
-                                              loadoutRect.width - _margin * 2 - _buttonSize,
+                                              loadoutRect.width - _margin * 3 - _buttonSize * 2,
                                               loadoutRect.height)
                                               .ContractedBy(_margin / 2f);
             Rect editLoadoutRect = new Rect(labelLoadoutRect.xMax + _margin,
                                              loadoutRect.yMin + ((loadoutRect.height - _buttonSize) / 2),
                                              _buttonSize,
                                              _buttonSize);
+            Rect forcedHoldRect = new Rect(labelLoadoutRect.xMax + _buttonSize + _margin * 2,
+                                            loadoutRect.yMin + ((loadoutRect.height - _buttonSize) /2),
+                                            _buttonSize,
+                                            _buttonSize);
 
             // fight or flight button
             HostilityResponseModeUtility.DrawResponseButton(responsePos, p);
@@ -312,6 +316,26 @@ namespace CombatExtended
             if (Widgets.ButtonImage(editLoadoutRect, _iconEdit))
             {
                 Find.WindowStack.Add(new Dialog_ManageLoadouts(p.GetLoadout()));
+            }
+
+            // clear forced held button
+            if (p.HoldTrackerAnythingHeld())
+            {
+                TooltipHandler.TipRegion(forcedHoldRect, "ClearForcedApparel".Translate()); // "Clear forced" is sufficient and that's what this is at the moment.
+                if (Widgets.ButtonImage(forcedHoldRect, _iconClearForced)) // also can re-use the icon for clearing forced at the moment.
+                {
+                    p.HoldTrackerClear(); // yes this will also delete records that haven't been picked up and thus not shown to the player...
+                }
+                TooltipHandler.TipRegion(forcedHoldRect, new TipSignal(delegate
+                {
+                    string text = "CE_ForcedHold".Translate() + ":\n";
+                    foreach (HoldRecord rec in LoadoutManager.GetHoldRecords(p))
+                    {
+                        if (!rec.pickedUp) continue;
+                        text = text + "\n   " + rec.thingDef.LabelCap + " x" + rec.count;
+                    }
+                    return text;
+                }, p.GetHashCode() * 613));
             }
 
             // STATUS BARS

--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
@@ -83,6 +83,25 @@ namespace CombatExtended
 			    return true;
 			return false;
 		}
+
+        /// <summary>
+        /// Is there any hold tracker records for this pawn?  This doesn't care if an item is actually present in the pawn's inventory.
+        /// </summary>
+        /// <param name="pawn">Pawn who's HoldTracker is to be polled</param>
+        /// <returns>bool indicating if the pawn has any HoldTracker records.</returns>
+        public static bool HoldTrackerAnythingHeld(this Pawn pawn)
+        {
+            List<HoldRecord> recs = LoadoutManager.GetHoldRecords(pawn);
+            if (recs == null || recs.NullOrEmpty())
+                return false;
+            return recs.Any(r => r.pickedUp);
+        }
+
+        public static void HoldTrackerClear(this Pawn pawn)
+        {
+            List<HoldRecord> recs = LoadoutManager.GetHoldRecords(pawn);
+            recs.Clear();
+        }
 		
 		/// <summary>
 		/// This should be called periodically so that HoldTracker can remove items that are no longer in the inventory via a method which isn't being watched.


### PR DESCRIPTION
Forced held items now show forced much like apparel (uses the same string).

Also the assign tab now has an extra button after edit loadout button which will show up if the pawn has any forced held items.  This button will clear the HoldTracker for that pawn.