### PR TITLE
Fixed a bug in the logic of what to drop from loadouts/holdTracker

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -71,7 +71,6 @@ namespace CombatExtended
             closestThing = null;
             count = 0;
 			carriedBy = null;
-			List<LoadoutSlot> processed = new List<LoadoutSlot>();  // not sure if this is worth it, probably.
 
             CompInventory inventory = pawn.TryGetComp<CompInventory>();
             if (inventory != null && inventory.container != null)

--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
@@ -335,37 +335,35 @@ namespace CombatExtended
         	// Complicated by the fact that we now consider ammo in guns as part of the inventory...
         	if (listing.Any())
         	{
-        		if (records != null)
-        		{
-        			// look at each remaining 'uneaten' thingdef in pawn's inventory.
-        			foreach (ThingDef def in listing.Keys)
-        			{
-        				// if we have a record (HoldTracker) for that thingdef...
-        				foreach (HoldRecord rec in records)
-        				{
-        					if (rec.thingDef != def)
-        					{
-        						// the item we have extra of has no HoldRecord, drop it.
-		    					dropThing = inventory.container.FirstOrDefault(t => t.def == def);
-		    					if (dropThing != null)
-		    					{
-			    					dropCount = listing[def].value > dropThing.stackCount ? dropThing.stackCount : listing[def].value;
-			    					return true;
-		    					}
-        					} else if (rec.thingDef == def && listing[def].value > rec.count)
-        					{
-        						// the item we have extra of HAS a HoldRecord but the amount carried is above the limit of the HoldRecord, drop extra.
-	        					dropThing = pawn.inventory.innerContainer.FirstOrDefault(t => t.def == def);
-	        					if (dropThing != null)
-	        					{
-		        					dropCount = listing[def].value - rec.count;
-		        					dropCount = dropCount > dropThing.stackCount ? dropThing.stackCount : dropCount;
-		        					return true;
-	        					}
-        					}
-        				}
-        			}
-        		} else {
+                if (records != null && !records.NullOrEmpty())
+                {
+                    // look at each remaining 'uneaten' thingdef in pawn's inventory.
+                    foreach (ThingDef def in listing.Keys)
+                    {
+                        HoldRecord rec = records.FirstOrDefault(r => r.thingDef == def);
+                        if (rec == null)
+                        {
+                            // the item we have extra of has no HoldRecord, drop it.
+                            dropThing = inventory.container.FirstOrDefault(t => t.def == def);
+                            if (dropThing != null)
+                            {
+                                dropCount = listing[def].value > dropThing.stackCount ? dropThing.stackCount : listing[def].value;
+                                return true;
+                            }
+                            else if (rec.count > listing[def].value)
+                            {
+                                // the item we have extra of HAS a HoldRecord but the amount carried is above the limit of the HoldRecord, drop extra.
+                                dropThing = pawn.inventory.innerContainer.FirstOrDefault(t => t.def == def);
+                                if (dropThing != null)
+                                {
+                                    dropCount = listing[def].value - rec.count;
+                                    dropCount = dropCount > dropThing.stackCount ? dropThing.stackCount : dropCount;
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                } else {
         			foreach (ThingDef def in listing.Keys)
         			{
 		        		dropThing = inventory.container.FirstOrDefault(t => t.def == def);

--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
@@ -288,7 +288,7 @@ namespace CombatExtended
         //  Probably not efficient but was easier to handle atm.
         static public bool GetExcessThing(this Pawn pawn, out Thing dropThing, out int dropCount)
         {
-	        //ProfoundDarkness: Thanks to erdelf on the RimWorldMod discord for helping me figure out some dictionary stuff and C# concepts related to 'Primitives' (pass by Value).
+	        //(ProfoundDarkness) Thanks to erdelf on the RimWorldMod discord for helping me figure out some dictionary stuff and C# concepts related to 'Primitives' (pass by Value).
         	CompInventory inventory = pawn.TryGetComp<CompInventory>();
         	Loadout loadout = pawn.GetLoadout();
         	List<HoldRecord> records = LoadoutManager.GetHoldRecords(pawn);


### PR DESCRIPTION
Changed how HoldTracker was used and didn't propagate that logic change out.

Issue had to do with HoldTracker could be empty and not just null.

Also cleaned up some logic that caused drop finding code to goof up pretty spectacularly if more than 1 HoldTracker record existed and the inventory wasn't 'just right'.