### PR TITLE
Modified motes and reportStrings for Reloading (includes turrets).

### DIFF
--- a/Defs/JobDefs/Jobs_CR.xml
+++ b/Defs/JobDefs/Jobs_CR.xml
@@ -6,7 +6,7 @@
 	<JobDef>
 		<defName>ReloadWeapon</defName>
 		<driverClass>CombatExtended.JobDriver_Reload</driverClass>
-		<reportString>Reloading weapon.</reportString>
+		<reportString>Reloading FlagSource TargetB with AmmoType.</reportString>
 	</JobDef>
 	
 	<JobDef>
@@ -32,7 +32,7 @@
 	<JobDef>
 		<defName>ReloadTurret</defName>
 		<driverClass>CombatExtended.JobDriver_ReloadTurret</driverClass>
-		<reportString>Reloading turret.</reportString>
+		<reportString>Reloading TurretType TargetA with TargetB.</reportString>
 	</JobDef>
   
   <JobDef>

--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -31,11 +31,16 @@
   <CE_TargetWidth>Target width</CE_TargetWidth>
 
   <!-- Reloading -->
+  <CE_ReloadingEquipment>equipped</CE_ReloadingEquipment>
+  <CE_ReloadingInventory>stored</CE_ReloadingInventory>
+  <CE_ReloadingMote>Reloading {0}!</CE_ReloadingMote>
+  <CE_ReloadingTurretMote>Reloading turret {0}.</CE_ReloadingTurretMote>
+  <CE_MannedTurret>Manned Turret</CE_MannedTurret>
+  <CE_AutoTurret>AutoTurret</CE_AutoTurret>
+  <!-- Are these still being used? -->
   <CE_UnloadLabel>Unload</CE_UnloadLabel>
   <CE_ReloadLabel>Reload</CE_ReloadLabel>
   <CE_ReloadDesc>Reloads this gun.</CE_ReloadDesc>
-  <CE_ReloadingMote>Reloading!</CE_ReloadingMote>
-  <CE_ReloadedMote>Reloaded!</CE_ReloadedMote>
   <CE_TurretReloading>Reloading</CE_TurretReloading>
 
   <!-- Inventory -->

--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -35,8 +35,8 @@
   <CE_ReloadingInventory>stored</CE_ReloadingInventory>
   <CE_ReloadingMote>Reloading {0}!</CE_ReloadingMote>
   <CE_ReloadingTurretMote>Reloading turret {0}.</CE_ReloadingTurretMote>
-  <CE_MannedTurret>Manned Turret</CE_MannedTurret>
-  <CE_AutoTurret>AutoTurret</CE_AutoTurret>
+  <CE_MannedTurret>manned turret</CE_MannedTurret>
+  <CE_AutoTurret>auto-turret</CE_AutoTurret>
   <!-- Are these still being used? -->
   <CE_UnloadLabel>Unload</CE_UnloadLabel>
   <CE_ReloadLabel>Reload</CE_ReloadLabel>

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -409,7 +409,6 @@ namespace CombatExtended
             curMagCountInt = newMagCount;
             if (turret != null) turret.isReloading = false;
             if (parent.def.soundInteract != null) parent.def.soundInteract.PlayOneShot(new TargetInfo(position,  Find.VisibleMap, false));
-            if (Props.throwMote) MoteMaker.ThrowText(position.ToVector3Shifted(), Find.VisibleMap, "CE_ReloadedMote".Translate());
         }
 
         private bool TryFindAmmoInInventory(out Thing ammoThing)

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
@@ -8,7 +8,16 @@ namespace CombatExtended
 {
     public class JobDriver_Reload : JobDriver
     {
+        #region Fields
         private CompAmmoUser _compReloader;
+        private bool inEquipment = false;
+        private bool inInventory = false;
+        private ThingWithComps initEquipment = null;
+        #endregion Fields
+
+        #region Properties
+        private string errorBase => this.GetType().Assembly.GetName().Name + " :: " + this.GetType().Name + " :: ";
+
         private CompAmmoUser compReloader
         {
             get
@@ -17,10 +26,20 @@ namespace CombatExtended
                 return _compReloader;
             }
         }
+        #endregion Properties
 
-		private bool inEquipment = false;
-		private bool inInventory = false;
-		private ThingWithComps initEquipment = null;
+        #region Methods
+        public override string GetReport()
+        {
+            string text = CE_JobDefOf.ReloadWeapon.reportString;
+            string flagSource = "";
+            if (inEquipment) flagSource = "CE_ReloadingEquipment".Translate();
+            if (inInventory) flagSource = "CE_ReloadingInventory".Translate();
+            text = text.Replace("FlagSource", flagSource);
+            text = text.Replace("TargetB", TargetThingB.def.LabelCap);
+            text = text.Replace("AmmoType", compReloader.currentAmmo.LabelCap);
+            return text;
+        }
 
         private bool HasNoGunOrAmmo()
         {
@@ -64,7 +83,7 @@ namespace CombatExtended
 			
             // Throw mote
             if (compReloader.Props.throwMote)
-                MoteMaker.ThrowText(pawn.Position.ToVector3Shifted(), Find.VisibleMap, "CE_ReloadingMote".Translate());
+                MoteMaker.ThrowText(pawn.Position.ToVector3Shifted(), Find.VisibleMap, string.Format("CE_ReloadingMote".Translate(), TargetThingB.def.LabelCap));
 
 			//Toil of do-nothing		
 			Toil waitToil = new Toil() { actor = pawn }; // actor was always null in testing...
@@ -86,5 +105,6 @@ namespace CombatExtended
             };
             yield return continueToil;
         }
+        #endregion Methods
     }
 }

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
@@ -36,8 +36,8 @@ namespace CombatExtended
             if (inEquipment) flagSource = "CE_ReloadingEquipment".Translate();
             if (inInventory) flagSource = "CE_ReloadingInventory".Translate();
             text = text.Replace("FlagSource", flagSource);
-            text = text.Replace("TargetB", TargetThingB.def.LabelCap);
-            text = text.Replace("AmmoType", compReloader.currentAmmo.LabelCap);
+            text = text.Replace("TargetB", TargetThingB.def.label);
+            text = text.Replace("AmmoType", compReloader.currentAmmo.label);
             return text;
         }
 

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
@@ -36,11 +36,11 @@ namespace CombatExtended
             string text = CE_JobDefOf.ReloadTurret.reportString;
             string turretType = (turret.def.hasInteractionCell ? "CE_MannedTurret" : "CE_AutoTurret").Translate();
             text = text.Replace("TurretType", turretType);
-            text = text.Replace("TargetA", TargetThingA.def.LabelCap);
+            text = text.Replace("TargetA", TargetThingA.def.label);
             if (compReloader.useAmmo)
-                text = text.Replace("TargetB", TargetThingB.def.LabelCap);
+                text = text.Replace("TargetB", TargetThingB.def.label);
             else
-                text = text.Replace("TargetB", compReloader.currentAmmo.LabelCap);
+                text = text.Replace("TargetB", compReloader.currentAmmo.label);
             return text;
         }
 

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
@@ -8,13 +8,16 @@ namespace CombatExtended
 {
     public class JobDriver_ReloadTurret : JobDriver
     {
+        #region Fields
+        private CompAmmoUser _compReloader;
+        #endregion Fields
+
         #region Properties
         private string errorBase => this.GetType().Assembly.GetName().Name + " :: " + this.GetType().Name + " :: ";
 
         private Building_TurretGunCE turret => TargetThingA as Building_TurretGunCE;
         private AmmoThing ammo => TargetThingB as AmmoThing;
 
-        private CompAmmoUser _compReloader;
         private CompAmmoUser compReloader
         {
             get
@@ -27,6 +30,20 @@ namespace CombatExtended
         #endregion
 
         #region Methods
+
+        public override string GetReport()
+        {
+            string text = CE_JobDefOf.ReloadTurret.reportString;
+            string turretType = (turret.def.hasInteractionCell ? "CE_MannedTurret" : "CE_AutoTurret").Translate();
+            text = text.Replace("TurretType", turretType);
+            text = text.Replace("TargetA", TargetThingA.def.LabelCap);
+            if (compReloader.useAmmo)
+                text = text.Replace("TargetB", TargetThingB.def.LabelCap);
+            else
+                text = text.Replace("TargetB", compReloader.currentAmmo.LabelCap);
+            return text;
+        }
+
         protected override IEnumerable<Toil> MakeNewToils()
         {
             // Error checking/input validation.
@@ -88,7 +105,7 @@ namespace CombatExtended
                 waitToil.actor.pather.StopDead();
                 turret.isReloading = true;
                 if (compReloader.Props.throwMote)
-                    MoteMaker.ThrowText(turret.Position.ToVector3Shifted(), Find.VisibleMap, "CE_ReloadingMote".Translate());
+                    MoteMaker.ThrowText(turret.Position.ToVector3Shifted(), Find.VisibleMap, string.Format("CE_ReloadingTurretMote".Translate(), TargetThingA.LabelCapNoCount));
                 compReloader.TryUnload();
             };
             waitToil.defaultCompleteMode = ToilCompleteMode.Delay;


### PR DESCRIPTION
Some of the remaining issues in #100.

Looking for feedback, in particular regarding turrets and the reportStrings in general.

-Removed "Reloaded!" mote (from CompAmmoUser).
-Added Keys (Translation strings) for motes, weapon source, and turret types.
-Modified Weapon and Turret Reload JobDrivers to use the new formatted motes.
-Added GetReport() override to generate a more detailed report of pawn activity.

Some light rearrangement and cleanup.

So reloading an equipped weapon shows the mote "Reloading Pistol!" and the reportString would say "Reloading equipped Pistol with <AmmoDef.LabelCap>".  Reloading an M240 turret shows the mote "Reloading turret M240" and the reportString "Reloading Manned Turret M240 with <AmmoDef.LabelCap>".