### PR TITLE
Attempted Fix Pickup-Drop Loop and cleaned up harmony patches some.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
@@ -61,13 +61,29 @@ namespace CombatExtended
 			HoldRecord rec = recs.FirstOrDefault(hr => hr.thingDef == job.targetA.Thing.def);
 			if (rec != null)
 			{
-				rec.count += job.count;
-				return;
+                if (rec.pickedUp)
+                {
+                    // modifying a record for which the pawn should have some of that thing in their inventory.
+                    CompInventory inventory = pawn.TryGetComp<CompInventory>();
+                    if (inventory != null)
+                        rec.count = inventory.container.TotalStackCountOfDef(rec.thingDef) + job.count;
+                    else
+                        rec.count += job.count; // probably won't generally follow this code path but good not to throw an error if possible.
+                }
+                else
+                {
+                    // modifying a record that hasn't been picked up... do it blind.
+                    rec.count += job.count;
+                }
+                // useful debug message...
+                //Log.Message(string.Concat("Job was issued to pickup items for this existing record: ", rec));
+                return;
 			}
 			// if we got this far we know that there isn't a record being stored for this thingDef...
 			rec = new HoldRecord(job.targetA.Thing.def, job.count);
 			recs.Add(rec);
-			Log.Message(string.Concat("Job was issued to pickup this record: ", rec));
+            // useful debug message...
+			//Log.Message(string.Concat("Job was issued to pickup for this new record: ", rec));
 		}
 		
 		/// <summary>

--- a/Source/CombatExtended/Detours/Detours_WorkGiver_InteractAnimal.cs
+++ b/Source/CombatExtended/Detours/Detours_WorkGiver_InteractAnimal.cs
@@ -38,10 +38,12 @@ namespace CombatExtended.Detours
                 }
             }
 
-            return new Job(JobDefOf.TakeInventory, thing)
+            Job job = new Job(JobDefOf.TakeInventory, thing)
             {
                 count = numToCarry
             };
+            pawn.Notify_HoldTrackerJob(job);
+            return job;
         }
     }
 }

--- a/Source/CombatExtended/Harmony/Harmony-Verb_TryStartCastOn_Patch.cs
+++ b/Source/CombatExtended/Harmony/Harmony-Verb_TryStartCastOn_Patch.cs
@@ -57,7 +57,6 @@ using Verse.AI;
             	{
             		foundBranch = true;
             		branchLabel = instruction.operand;
-            		Log.Message(instruction.operand.ToString());
             	}
             	
             	if (!foundCall && instruction.opcode == OpCodes.Call && ((MethodInfo)instruction.operand).Name.Contains("TryFindShootLineFromTo"))

--- a/Source/CombatExtended/Harmony/Harmony-WorkGiver_InteractAnimal-TakeFoodForAnimalInteractJob.cs
+++ b/Source/CombatExtended/Harmony/Harmony-WorkGiver_InteractAnimal-TakeFoodForAnimalInteractJob.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Harmony;
+using Verse;
+using RimWorld;
+using Verse.AI;
+
+// (ProfoundDarkness) Disabled this as I forgot to check and see if there was a detour again... and there was.  Kept around as reference for eventual Harmony conversion of detours after A17.
+
+namespace CombatExtended.Harmony
+{
+    /* Targeting RimWorld.WorkGiver_InteractAnimal.TakeFoodForAnimalInteractJob()
+     * Specifically inserting a notification right before the return in the line:
+     *  return new Job(JobDefOf.TakeInventory, thing)
+     * which will notify HoldTracker to hold onto the item.
+     * 
+     * There isn't really an obvious code way to put what happens but something sortof like this:
+     *  Job job = new Job(JobDefOf.TakeInventory, thing);
+     *  pawn.Notify_HoldTracker(job);
+     *  return job;
+     *  
+     * Except that no new local variable is being created.
+     */
+
+    [HarmonyPatch(typeof(WorkGiver_InteractAnimal))]
+    [HarmonyPatch("TakeFoodForAnimalInteractJob")]
+    [HarmonyPatch(new Type[] { typeof(Pawn), typeof(Pawn) })]
+    static class Harmony_WorkGiver_InteractAnimal_TakeFoodforAnimalInteractJob
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            // Note: First argument is the Pawn that will get the job.
+
+            bool foundTakeInventory = false;
+            int jobLocalIndex = -1;
+            int instructionIndex = 0;
+            int lastLoadJobIndex = -1;
+            LocalVariableInfo jobInfo = null;
+
+            // First we look for stuff.
+            foreach (CodeInstruction instruction in instructions)
+            {
+                // Locate the local variable that the job gets stored to.
+                if (foundTakeInventory && jobLocalIndex < 0)
+                    jobLocalIndex = HarmonyBase.OpcodeStoreIndex(instruction);
+
+                if (instruction.opcode == OpCodes.Ldsfld && (instruction.operand as FieldInfo).FieldType == typeof(JobDef) && (instruction.operand as FieldInfo).Name == "TakeInventory")
+                    foundTakeInventory = true;
+
+                // Locate the last local load instruction coresponding to the local variable that the job was stored.  Insertion point is above this.
+                if (jobLocalIndex >= 0 && HarmonyBase.OpcodeLoadIndex(instruction) == jobLocalIndex)
+                {
+                    lastLoadJobIndex = instructionIndex;
+                    jobInfo = instruction.operand as LocalVariableInfo;  // capture the metadata about this instruction for use later.
+                }
+                instructionIndex++;
+            }
+
+            // now lets start altering code...
+            int curInstructionIndex = 0;
+            foreach (CodeInstruction instruction in instructions)
+            {
+                if (lastLoadJobIndex == curInstructionIndex)
+                {
+                    // first argument we need is the pawn (1st argument in host method)...
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    // next argument is the job...
+                    yield return HarmonyBase.MakeLocalLoadInstruction(jobLocalIndex, jobInfo);
+                    // now the call to the notifier...
+                    yield return new CodeInstruction(OpCodes.Call, typeof(Utility_HoldTracker).GetMethod("Notify_HoldTrackerJob", new Type[] { typeof(Pawn), typeof(Job) }));
+                }
+
+                yield return instruction;
+                curInstructionIndex++;
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -1,6 +1,17 @@
 ﻿using System.Reflection;
 using Harmony;
 using Verse;
+using System;
+using System.Reflection.Emit;
+
+/* Note to those unfamiliar with Reflection/Harmony (like me, ProfoundDarkness), operands have some specific types and it's useful to know these to make good patches (Transpiler).
+ * Below I'm noting the operators and what type of operand I've observed.
+ * 
+ * local variable operands who's index is < 4 (so _0, _1, _2, _3) seem to have an operand of null.
+ * 
+ * local variable operands (ex Ldloc_s, Stloc_s) == LocalVariableInfo
+ * field operands (ex ldfld) == FieldInfo
+ */
 
 namespace CombatExtended.Harmony
 {
@@ -33,5 +44,79 @@ namespace CombatExtended.Harmony
 				return harmony;
 			}
 		}
-	}
+
+        #region Utility_Methods
+        /// <summary>
+        /// Return a CodeInstruction object with the correct opcode to fetch a local variable at a specific index.
+        /// </summary>
+        /// <param name="index">int value specifying the local variable index to fetch.</param>
+        /// <param name="info">LocalVariableInfo optional if you've stored the metadata from a load/save instruction previously.</param>
+        /// <returns>CodeInstruction object with the correct opcode to fetch a local variable into the evaluation stack.</returns>
+        internal static CodeInstruction MakeLocalLoadInstruction(int index, LocalVariableInfo info = null)
+        {
+            // argument check...
+            if (index < 0 || index > UInt16.MaxValue)
+                throw new ArgumentException("Index must be greater than 0 and less than " + uint.MaxValue.ToString() + ".");
+
+            // the first 4 are easy...  (ProfoundDarkness)NOTE: I've only ever observed these with null operands.
+            switch (index)
+            {
+                case 0:
+                    return new CodeInstruction(OpCodes.Ldloc_0);
+                case 1:
+                    return new CodeInstruction(OpCodes.Ldloc_1);
+                case 2:
+                    return new CodeInstruction(OpCodes.Ldloc_2);
+                case 3:
+                    return new CodeInstruction(OpCodes.Ldloc_3);
+            }
+
+            object objIndex;
+            // proper type info for the other items.
+            if (info != null && info.LocalIndex == index)
+                objIndex = info;
+            else
+                objIndex = index;
+
+            if (index > Byte.MaxValue) return new CodeInstruction(OpCodes.Ldloc, objIndex);
+            return new CodeInstruction(OpCodes.Ldloc_S, objIndex);
+        }
+
+        /// <summary>
+        /// Return the index of a local variable (based on storage opcode).
+        /// </summary>
+        /// <param name="instruction">CodeInstruction object from Harmony</param>
+        /// <returns>int index of the local variable the instruction refers to. -1 if the opcode wasn't a recognized storage opcode.</returns>
+        internal static int OpcodeStoreIndex(CodeInstruction instruction)
+        {
+            if (instruction.opcode == OpCodes.Stloc_0) return 0;
+            if (instruction.opcode == OpCodes.Stloc_1) return 1;
+            if (instruction.opcode == OpCodes.Stloc_2) return 2;
+            if (instruction.opcode == OpCodes.Stloc_3) return 3;
+            if (instruction.opcode == OpCodes.Stloc_S) // UInt8
+                return (instruction.operand as LocalVariableInfo).LocalIndex;
+            if (instruction.opcode == OpCodes.Stloc) // UInt16
+                return (instruction.operand as LocalVariableInfo).LocalIndex;
+            return -1; // error, unrecognized opcode so can check this if we DIDN'T get an apt opcode.
+        }
+
+        /// <summary>
+        /// REturn the index of a local variable (based on load opcode).
+        /// </summary>
+        /// <param name="instruction">CodeInstruction object from Harmony</param>
+        /// <returns>int index of the local variable the instruction refers to.  -1 if the opcode wasn't a recognized load opcode.</returns>
+        internal static int OpcodeLoadIndex(CodeInstruction instruction)
+        {
+            if (instruction.opcode == OpCodes.Ldloc_0) return 0;
+            if (instruction.opcode == OpCodes.Ldloc_1) return 1;
+            if (instruction.opcode == OpCodes.Ldloc_2) return 2;
+            if (instruction.opcode == OpCodes.Ldloc_3) return 3;
+            if (instruction.opcode == OpCodes.Ldloc_S) // UInt8
+                return (instruction.operand as LocalVariableInfo).LocalIndex;
+            if (instruction.opcode == OpCodes.Ldloc) // UInt16
+                return (instruction.operand as LocalVariableInfo).LocalIndex;
+            return -1;
+        }
+        #endregion Utility_Methods
+    }
 }


### PR DESCRIPTION
Main Focus (issue #141):
-Added a HoldTracker notification to the detour of WorkGiver_InteractAnimal.TakeFoodForAnimalInteractJob.
-Modified the HoldTracker notification code to be a little more sane about how many things to hold onto.
-Removed (remark) some debug messages related to Notify_HoldTrackerJob.

Assides included in this:
-Cleaned out a bunch of debug log messages that got left behind in various Harmony patches.
-Moved some utility methods out of a specific patch and exposed them in HarmonyBase for use by any patcher.
-Added a new utility method to HarmonyBase.
-Attempted to perform the WorkGiver_InteractAnimal.TakeFoodForAnimalInteractJob modification as a Harmony patch before checking if there was a Detour (which there was).  Code is excluded from the project but the file is likely useful in the future if we convert more Detours to Harmony.