### PR TITLE
Fixed an NRE related to generic ammo fetching for loadouts.

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -211,7 +211,7 @@ namespace CombatExtended
 				}
                 if (curThing != null)
                 {
-                    if (!curSlot.thingDef.IsNutritionGivingIngestible && findCount / curSlot.count <= 0.5f) curPriority = ItemPriority.LowStock;
+                    if (curThing.def.IsNutritionGivingIngestible && findCount / curSlot.count <= 0.5f) curPriority = ItemPriority.LowStock;
                     else curPriority = ItemPriority.Low;
                 }
             }


### PR DESCRIPTION
Surprised I didn't stumble on this sooner considering how often I've had pawns fetching generic pistol ammo but kasidoo (Discord) found this issue with Charged Rifles.

Issue was some old code from before generics assuming that all loadoutslots were thingdef based.  Fixed by referencing the found thing's def instead of the slot to decide if ingestible.