### PR TITLE
Attempted fix to pawns getting stuck unloading their inventory.

### DIFF
--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Harmony\Harmony-HediffWithComps.cs" />
     <Compile Include="Harmony\Harmony-Hediff_MissingPart.cs" />
     <Compile Include="Harmony\Harmony-JobDriverWait.cs" />
+    <Compile Include="Harmony\Harmony-JobGiver_UnloadYourInventory.cs" />
     <Compile Include="Harmony\Harmony-MassUtility.cs" />
     <Compile Include="Harmony\Harmony-Pawn_EquipmentTracker.cs" />
     <Compile Include="Harmony\Harmony-Pawn_HealthTracker.cs" />

--- a/Source/CombatExtended/Harmony/Harmony-JobGiver_UnloadYourInventory.cs
+++ b/Source/CombatExtended/Harmony/Harmony-JobGiver_UnloadYourInventory.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Harmony;
+using Verse;
+using RimWorld;
+using UnityEngine;
+using Verse.AI;
+
+/* Concept: Change the line:
+ *  if (!pawn.inventory.UnloadEverything)
+ * to:
+ *  if (!pawn.inventory.UnloadEverything && !pawn.HasAnythingForDrop())
+ * In the IL the logic is a tad different...
+ *  L_0006: callvirt Boolean get_UnloadEverything()
+ *  L_000b: brtrue Label #2
+ *  L_0010: ldnull
+ *  L_0011: br Label #0
+ * 
+ */
+
+namespace CombatExtended.Harmony
+{
+    [HarmonyPatch(typeof(JobGiver_UnloadYourInventory), "TryGiveJob", new Type[] { typeof(Pawn) } )]
+    static class Harmony_JobGiver_UnloadYourInventory
+    {
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, MethodBase source, ILGenerator il)
+        {
+            // another new thing, find the desired parameter instead of assuming it will be the same.
+            ParameterInfo[] args = source.GetParameters();
+            int argIndex = -1;
+            for (int i = 0; i < args.Length; i++)
+            {
+                if (args[i].ParameterType.Equals(typeof(Pawn)))
+                {
+                    argIndex = i + 1; // parrameters are 0 based because of instance.
+                    break;
+                }
+            }
+
+            Label branchFalse = il.DefineLabel(); // since the logic is gettin changed more than I thought, need a new label.
+
+            Label? branchTrue = null;
+
+            int patchPhase = 0;
+            foreach (CodeInstruction instruction in instructions)
+            {
+                // Looking for the ldnull instruction to add a label to it.
+                if (patchPhase == 1 && instruction.opcode.Equals(OpCodes.Ldnull))
+                {
+                    instruction.labels.Add(branchFalse);
+
+                    patchPhase = 2;
+                }
+
+                // The first branch we find is the one to remember.  This is also the insertion point...
+                if (patchPhase == 0 && instruction.opcode.Equals(OpCodes.Brtrue))
+                {
+                    branchTrue = instruction.operand as Label?;
+
+                    // If the inventory isn't set to unload mode, short circuit and jump to return null path...
+                    yield return new CodeInstruction(OpCodes.Brfalse, branchFalse);
+
+                    // load the arg which is the pawn.
+                    yield return new CodeInstruction(OpCodes.Ldarg, argIndex);
+                    // load call to see if the pawn has anything they can drop according to loadout/holdtracker.
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Utility_HoldTracker), "HasAnythingForDrop"));
+
+                    // leave the current instruction, branch true, alone...
+
+                    patchPhase = 1;
+                }
+
+                yield return instruction;
+
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -41,10 +41,10 @@ namespace CombatExtended.Harmony
         public static void InitPatches()
         {
             // Remove the remark on the following to debug all auto patches.
-            //HarmonyInstance.DEBUG = true;
+            HarmonyInstance.DEBUG = true;
             instance.PatchAll(Assembly.GetExecutingAssembly());
             // Keep the following remarked to also debug manual patches.
-            //HarmonyInstance.DEBUG = false;
+            HarmonyInstance.DEBUG = false;
 
             // Manual patches
             PatchThingOwner();
@@ -194,6 +194,11 @@ namespace CombatExtended.Harmony
             return doSwapCall(instructions, il, to.GetGenericArguments(), from.GetGenericArguments());
         }
         */
+
+        internal static LocalBuilder[] GetLocals(ILGenerator il)
+        {
+            return Traverse.Create(il).Field("locals").GetValue<LocalBuilder[]>();
+        }
 
         /// <summary>
         /// branchOps is used by isBranch utility method.


### PR DESCRIPTION
The issue was that the jobgiver was unaware of loadouts and so would re-issue jobs that were closed successfully.

It was a bit weird in that they didn't always get stuck, suppose a race condition of sorts where sometimes the unloadinventory flag would get cleaned and others it wouldn't.

The patch proved a tad harder than expected since I had thought I needed an OR condition but I actually needed an AND.

Should take care of #70 finally.