### PR TITLE
Mostly worked on holdtracker ammo system disabled issues...

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -272,6 +272,10 @@ namespace CombatExtended
                 }
             }
 
+            // secondary branch for if we ended up being called up by a turret somehow...
+            if (turret != null)
+                turret.OrderReload();
+
             // Issue reload job
             if (wielder != null)
             {

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
@@ -56,8 +56,10 @@ namespace CombatExtended
             if (reloadingInventory) flagSource = "CE_ReloadingInventory".Translate();
             text = text.Replace("FlagSource", flagSource);
             text = text.Replace("TargetB", weapon.def.label);
-            text = text.Replace("AmmoType", compReloader.currentAmmo.label);
-            return text;
+            if (Controller.settings.EnableAmmoSystem)
+                text = text.Replace("AmmoType", compReloader.currentAmmo.label);
+            else
+                text = text.Replace("AmmoType", "CE_ReloadingGenericAmmo".Translate()); return text;
         }
 
         /// <summary>

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_ReloadTurret.cs
@@ -40,7 +40,7 @@ namespace CombatExtended
             if (compReloader.useAmmo)
                 text = text.Replace("TargetB", TargetThingB.def.label);
             else
-                text = text.Replace("TargetB", compReloader.currentAmmo.label);
+                text = text.Replace("TargetB", "CE_ReloadingGenericAmmo".Translate());
             return text;
         }
 
@@ -57,7 +57,7 @@ namespace CombatExtended
                 Log.Error(string.Concat(errorBase, "TargetThingA (Building_TurretGunCE) is missing it's CompAmmoUser."));
                 yield return null;
             }
-            if (ammo == null)
+            if (compReloader.useAmmo && ammo == null)
             {
                 Log.Error(string.Concat(errorBase, "TargetThingB is either null or not an AmmoThing."));
                 yield return null;

--- a/Source/CombatExtended/CombatExtended/Jobs/WorkGiver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/WorkGiver_ReloadTurret.cs
@@ -47,8 +47,8 @@ namespace CombatExtended
 
             if (!turret.CompAmmo.useAmmo)
             {
-                //return new Job(DefDatabase<JobDef>.GetNamed("ReloadTurret"), t, null);
-                return null;
+                return new Job(DefDatabase<JobDef>.GetNamed("ReloadTurret"), t, null);
+                //return null;
             }
 
             Thing ammo = GenClosest.ClosestThingReachable(pawn.Position, pawn.Map,

--- a/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Utility_HoldTracker.cs
@@ -290,7 +290,7 @@ namespace CombatExtended
         	{
 				storage.Add(pawn.equipment.Primary.def, new Integer(1));
 				gun = pawn.equipment.Primary.TryGetComp<CompAmmoUser>();
-				if (gun != null)
+				if (gun != null && gun.useAmmo)
 					storage.Add(gun.currentAmmo, new Integer(gun.curMagCount));
         	}
 			// get the pawn's inventory
@@ -300,7 +300,7 @@ namespace CombatExtended
 					storage.Add(thing.def, new Integer(0));
 				storage[thing.def].value += thing.stackCount;
 				gun = thing.TryGetComp<CompAmmoUser>();
-				if (gun != null)
+				if (gun != null && gun.useAmmo)
 				{
 					if (storage.ContainsKey(gun.currentAmmo))
 						storage[gun.currentAmmo].value += gun.curMagCount;

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -41,10 +41,10 @@ namespace CombatExtended.Harmony
         public static void InitPatches()
         {
             // Remove the remark on the following to debug all auto patches.
-            HarmonyInstance.DEBUG = true;
+            //HarmonyInstance.DEBUG = true;
             instance.PatchAll(Assembly.GetExecutingAssembly());
             // Keep the following remarked to also debug manual patches.
-            HarmonyInstance.DEBUG = false;
+            //HarmonyInstance.DEBUG = false;
 
             // Manual patches
             PatchThingOwner();


### PR DESCRIPTION
CompAmmoUser - Added a check if the thing trying to be reloaded is a turret and if so pass the reload job on... this code path is untested though as it turns out it could never run...

JobDriver_Reload* - altered the inspect strings of the jobs so as to avoid NRE when ammo system disabled.  JobDriver_Reload is re-patched since somehow git decided the fix should be removed in a different commit.

JobGiver_CheckReload has been modified to handle auto-reloads if the ammo system is inactive.  Also modified to perform auto reloads if the pawn does NOT have a loadout but does have a weapon and the right ammo in inventory.  The changes made to support ammoSystem being off made it easy to extend to no loadouts.

WorkGiver_Reload Turret - removed a line of code that was remarked in JobOnThing so that this will again trigger reloads of turrets when ammo system is off.

Utility_HoldTracker methods relating to building a picture of the pawn's inventory (ie to figure out what to drop) now consider if the ammo system is disabled and will not try to count ammo in the guns a pawn may have equipped or in inventory.

Should fix issue #190.