### PR TITLE
Fixed no xp from shooting bug (thanks to AndrewZo)

### DIFF
--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -51,7 +51,7 @@ namespace CombatExtended
         public ProjectilePropertiesCE projectilePropsCE => this.ProjectileDef.projectile as ProjectilePropertiesCE;
 
         // Returns either the pawn aiming the weapon or in case of turret guns the turret operator or null if neither exists
-        public Pawn ShooterPawn => CasterPawn == null ? CasterPawn : CE_Utility.TryGetTurretOperator(this.caster);
+        public Pawn ShooterPawn => CasterPawn != null ? CasterPawn : CE_Utility.TryGetTurretOperator(this.caster);
 
         protected CompCharges CompCharges
         {

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_ShootCE.cs
@@ -16,7 +16,7 @@ namespace CombatExtended
         private const int aimTicksMin = 30;
         private const int aimTicksMax = 240;
 
-        // XP amounts
+        // XP amounts  As of A17 non-hostile pawns/objects are (per shot) worth 6xp and hostile pawns are worth 240 xp.
         private const float objectXP = 0.1f;
         private const float pawnXP = 0.75f;
         private const float hostileXP = 3.6f;
@@ -31,6 +31,7 @@ namespace CombatExtended
         private CompFireModes compFireModes = null;
         private bool isAiming = false;
         private int xpTicks = 0;                        // Tracker to see how much xp should be awarded for time spent aiming + bursting
+        const float BaseXPMultiplyer = 0.5f;            // the amount warmup time is multiplied by for the quickshot fire mode (initial XP)
 
         #endregion
 
@@ -116,7 +117,7 @@ namespace CombatExtended
         public override void WarmupComplete()
         {
             if (xpTicks <= 0)
-                xpTicks = Mathf.CeilToInt(verbProps.warmupTime * 0.5f);
+                xpTicks = Mathf.CeilToInt(verbProps.warmupTime * BaseXPMultiplyer);
 
             if (this.ShouldAim && !this.isAiming)
             {


### PR DESCRIPTION
AndrewZo (github) pinpointed the root cause, verified in debugger and verified fix.

Issue #188 should be fixed.
Melee does seem to yield XP, though possibly only from successful hits on mobile targets.  I wouldn't expect any XP from punching walls and trees.