### PR TITLE
Addressed missing elements and quick/dirty patch widths on assign tab...

### DIFF
--- a/Defs/Misc/PawnColumnDefs/PawnColumns_CE.xml
+++ b/Defs/Misc/PawnColumnDefs/PawnColumns_CE.xml
@@ -7,5 +7,19 @@
     <workerClass>CombatExtended.PawnColumnWorker_Loadout</workerClass>
     <sortable>true</sortable>
   </PawnColumnDef>
+  
+  <PawnColumnDef>
+	<defName>CEMass</defName>
+	<label>mass</label>
+	<workerClass>CombatExtended.PawnColumnWorker_MassBulkBar</workerClass>
+	<sortable>true</sortable>
+  </PawnColumnDef>
 
+  <PawnColumnDef>
+	<defName>CEBulk</defName>
+	<label>bulk</label>
+	<workerClass>CombatExtended.PawnColumnWorker_MassBulkBar</workerClass>
+	<sortable>true</sortable>
+  </PawnColumnDef>
+  
 </Defs>

--- a/Patches/Core/Misc/PawnTables/PawnTables.xml
+++ b/Patches/Core/Misc/PawnTables/PawnTables.xml
@@ -6,6 +6,10 @@
 		<value>
       <li>GapSmall</li>
 			<li>Loadout</li>
+	  <li>GapSmall</li>
+			<li>CEMass</li>
+	  <li>GapSmall</li>
+			<li>CEBulk</li>
 			<li>RemainingSpace</li>
 		</value>
 	</Operation>

--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -141,6 +141,7 @@
     <Compile Include="CombatExtended\Jobs\JobGiver_ConfigurableHostilityResponse.cs" />
     <Compile Include="CombatExtended\Jobs\JobGiver_TakeAndEquip.cs" />
     <Compile Include="CombatExtended\Loadouts\HoldRecord.cs" />
+    <Compile Include="CombatExtended\Loadouts\PawnColumnWorker_MassBulkBars.cs" />
     <Compile Include="CombatExtended\Loadouts\Tracker.cs" />
     <Compile Include="CombatExtended\Loadouts\PawnColumnWorker_Loadout.cs" />
     <Compile Include="CombatExtended\Loadouts\Utility_HoldTracker.cs" />
@@ -238,6 +239,7 @@
     <Compile Include="Harmony\Harmony-MassUtility.cs" />
     <Compile Include="Harmony\Harmony-Pawn_EquipmentTracker.cs" />
     <Compile Include="Harmony\Harmony-Pawn_HealthTracker.cs" />
+    <Compile Include="Harmony\Harmony-QuickAndDirtyShrinkWorkers.cs" />
     <Compile Include="Harmony\Harmony-SmokepopBelt.cs" />
     <Compile Include="Harmony\Harmony-ThingOwner.cs" />
     <Compile Include="Harmony\Harmony-TooltipUtility.cs" />

--- a/Source/CombatExtended/CombatExtended/Loadouts/PawnColumnWorker_Loadout.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/PawnColumnWorker_Loadout.cs
@@ -15,6 +15,9 @@ namespace CombatExtended
 
         private const int ManageOutfitsButtonHeight = 32;
 
+        internal static float _MinWidth = 97f;  //194f default
+        internal static float _OptimalWidth = 177;  //354f default
+
         public override void DoHeader(Rect rect, PawnTable table)
         {
             base.DoHeader(rect, table);
@@ -87,7 +90,6 @@ namespace CombatExtended
                 num3 += 4f;
             }
 
-            // Edit loadout button
             Rect assignTabRect = new Rect(num3, rect.y + 2f, (float)num2, rect.height - 4f);
             if (Widgets.ButtonText(assignTabRect, "AssignTabEdit".Translate(), true, false, true))
             {
@@ -98,12 +100,12 @@ namespace CombatExtended
 
         public override int GetMinWidth(PawnTable table)
         {
-            return Mathf.Max(base.GetMinWidth(table), Mathf.CeilToInt(194f));
+            return Mathf.Max(base.GetMinWidth(table), Mathf.CeilToInt(_MinWidth));
         }
 
         public override int GetOptimalWidth(PawnTable table)
         {
-            return Mathf.Clamp(Mathf.CeilToInt(354f), this.GetMinWidth(table), this.GetMaxWidth(table));
+            return Mathf.Clamp(Mathf.CeilToInt(_OptimalWidth), this.GetMinWidth(table), this.GetMaxWidth(table));
         }
 
         public override int GetMinHeaderHeight(PawnTable table)

--- a/Source/CombatExtended/CombatExtended/Loadouts/PawnColumnWorker_MassBulkBars.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/PawnColumnWorker_MassBulkBars.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RimWorld;
+using Verse;
+using UnityEngine;
+
+namespace CombatExtended
+{
+    // Mostly based on PawnColumnWorker_Loadout and adapted for mass/bulk.
+    public class PawnColumnWorker_MassBulkBar : PawnColumnWorker
+    {
+        private const int TopAreaHeight = 65;
+        private const string BarMass = "CEMass";
+        private const string BarBulk = "CEBulk";
+        private static int _MinWidth = 50;
+        private static int _OptimalWidth = 150;
+
+        public override void DoHeader(Rect rect, PawnTable table)
+        {
+            base.DoHeader(rect, table);
+        }
+
+        public override void DoCell(Rect rect, Pawn pawn, PawnTable table)
+        {
+            CompInventory inventory = pawn.TryGetComp<CompInventory>();
+            if (inventory == null)
+            {
+                return;
+            }
+            Rect barRect = new Rect(rect.x, rect.y + 2f, rect.width, rect.height - 4f);
+            if (this.def.defName.Equals(BarMass))
+            {
+                Utility_Loadouts.DrawBar(barRect, inventory.currentBulk, inventory.capacityBulk, "", pawn.GetBulkTip());
+            }
+            if (this.def.defName.Equals(BarBulk))
+            {
+                Utility_Loadouts.DrawBar(barRect, inventory.currentWeight, inventory.capacityWeight, "", pawn.GetWeightTip());
+            }
+        }
+
+        public override int GetMinWidth(PawnTable table)
+        {
+            return Mathf.Max(base.GetMinWidth(table), Mathf.CeilToInt(_MinWidth));
+        }
+
+        public override int GetOptimalWidth(PawnTable table)
+        {
+            return Mathf.Clamp(Mathf.CeilToInt(_OptimalWidth), this.GetMinWidth(table), this.GetMaxWidth(table));
+        }
+
+        public override int GetMinHeaderHeight(PawnTable table)
+        {
+            return Mathf.Max(base.GetMinHeaderHeight(table), TopAreaHeight);
+        }
+
+        public override int Compare(Pawn a, Pawn b)
+        {
+            CompInventory inventoryA = a.TryGetComp<CompInventory>();
+            CompInventory inventoryB = b.TryGetComp<CompInventory>();
+            if (inventoryA == null || inventoryB == null)
+                return 0;
+
+            if (this.def.defName.Equals(BarMass))
+            {
+                return (inventoryA.capacityBulk - inventoryA.currentBulk).CompareTo(inventoryB.capacityBulk - inventoryB.currentBulk);
+            }
+            if (this.def.defName.Equals(BarBulk))
+            {
+                return (inventoryA.capacityWeight - inventoryA.currentWeight).CompareTo(inventoryB.capacityWeight - inventoryB.currentWeight);
+            }
+            return 0;
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Harmony-QuickAndDirtyShrinkWorkers.cs
+++ b/Source/CombatExtended/Harmony/Harmony-QuickAndDirtyShrinkWorkers.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Harmony;
+using Verse;
+using RimWorld;
+using UnityEngine;
+using Verse.AI;
+
+namespace CombatExtended.Harmony
+{
+    static class PatchCoreWorkers
+    {
+        static readonly string logPrefix = Assembly.GetExecutingAssembly().GetName().Name + " :: " + typeof(PatchCoreWorkers).Name + " :: ";
+
+        public static void Patch()
+        {
+            Type[] targetTypes = new Type[] { typeof(PawnColumnWorker_Outfit), typeof(PawnColumnWorker_DrugPolicy) };
+            string[] targetNames = new string[] { "GetMinWidth", "GetOptimalWidth" };
+            HarmonyMethod[] transpilers = new HarmonyMethod[] { new HarmonyMethod(typeof(PatchCoreWorkers), "MinWidth"),
+                                                                new HarmonyMethod(typeof(PatchCoreWorkers), "OptWidth")};
+
+            for (int i = 0; i < targetTypes.Length; i++)
+            {
+                for (int j = 0; j < targetNames.Length; j++)
+                {
+                    MethodBase method = targetTypes[i].GetMethod(targetNames[j], AccessTools.all);
+                    HarmonyBase.instance.Patch(method, null, null, (HarmonyMethod) transpilers[j]);
+                }
+            }
+
+        }
+
+        [HarmonyTranspiler]
+        static IEnumerable<CodeInstruction> MinWidth(IEnumerable<CodeInstruction> instructions)
+        {
+            foreach (CodeInstruction instruction in instructions)
+            {
+                if (instruction.opcode == OpCodes.Ldc_R4)
+                {
+                    instruction.operand = PawnColumnWorker_Loadout._MinWidth;
+                }
+                yield return instruction;
+            }
+        }
+        [HarmonyTranspiler]
+        static IEnumerable<CodeInstruction> OptWidth(IEnumerable<CodeInstruction> instructions)
+        {
+            foreach (CodeInstruction instruction in instructions)
+            {
+                if (instruction.opcode == OpCodes.Ldc_R4)
+                {
+                    instruction.operand = PawnColumnWorker_Loadout._OptimalWidth;
+                }
+                yield return instruction;
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/HarmonyBase.cs
+++ b/Source/CombatExtended/Harmony/HarmonyBase.cs
@@ -53,6 +53,7 @@ namespace CombatExtended.Harmony
             PatchThingOwner();
             PatchHediffWithComps();
             Harmony_GenRadial_RadialPatternCount.Patch();
+            PatchCoreWorkers.Patch();
         }
 
         #region Patch helper methods


### PR DESCRIPTION
Don't know what issue, don't care, too hot... (#172 I guess)

Ripped out my attempt to add back in the nice CE buttons on the interface completely.

Added bulk and mass bars, they look OK.  They are sortable too.  The sort value is based on available capacity.

Added static variables to PawnColumnWorker_Loadout.  These are very important to the assign tab in general and should be used appropriately.

Added quick and dirty patch to widths of the Core assign workers, they take their values from PawnColumnWorker_Loadout variables so set those variables to change the widths 'till it's desired.

May have accidentally removed some remarks while ripping out my start at porting the CE interface...