### PR TITLE
Modified JobGiver_UpdateLoadout and JobDriver_TakeFromOther...

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_TakeFromOther.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_TakeFromOther.cs
@@ -9,6 +9,11 @@ using UnityEngine;
 
 namespace CombatExtended
 {
+    /* Regarding multi reservation...
+     * As long as it's all the same job reserving the animal (sourceInd) it works out fine.
+     * Need to check if the target still has the desired thing because if a pawn can take the entire stack then the thing object's container is changed rather than destroyed.
+     * It's when a pawn takes a partial stack that new thing objects are created and the difference is deducted from the previously existing thing's stack count.
+     */
 	public class JobDriver_TakeFromOther : JobDriver
 	{
 		private TargetIndex thingInd = TargetIndex.A;
@@ -44,25 +49,42 @@ namespace CombatExtended
 			return text;
 		}
 
+        private bool DeadTakePawn()
+        {
+            return takePawn.Dead;
+        }
 		
 		protected override IEnumerable<Toil> MakeNewToils()
 		{
 			this.FailOnDespawnedNullOrForbidden(sourceInd);
-			yield return Toils_Reserve.Reserve(sourceInd);
+            this.FailOnDestroyedNullOrForbidden(thingInd);
+            this.FailOn(DeadTakePawn);
+            // We could set a slightly more sane value here which would prevent a hoard of pawns moving from pack animal to pack animal...
+            // Also can enforce limits via JobGiver keeping track of how many things it's given away from each pawn, it's a small case though...
+			yield return Toils_Reserve.Reserve(sourceInd, int.MaxValue, 0, null);
 			yield return Toils_Goto.GotoThing(sourceInd, PathEndMode.Touch);
 			yield return Toils_General.Wait(10);
 			yield return new Toil {
 				initAction = delegate
 				{
-					takePawn.inventory.innerContainer.TryTransferToContainer(targetItem, pawn.inventory.innerContainer, CurJob.count);
-					if (doEquip)
-					{
-						CompInventory compInventory = pawn.TryGetComp<CompInventory>();
-						if (compInventory != null)
-							compInventory.TrySwitchToWeapon((ThingWithComps)targetItem);
-					}
+                    // if the targetItem is no longer in the takePawn's inventory then another pawn already took it and we fail...
+                    if (takePawn.inventory.innerContainer.Contains(targetItem))
+                    {
+                        int amount = targetItem.stackCount < CurJob.count ? targetItem.stackCount : CurJob.count;
+                        takePawn.inventory.innerContainer.TryTransferToContainer(targetItem, pawn.inventory.innerContainer, amount);
+                        if (doEquip)
+                        {
+                            CompInventory compInventory = pawn.TryGetComp<CompInventory>();
+                            if (compInventory != null)
+                                compInventory.TrySwitchToWeapon((ThingWithComps)targetItem);
+                        }
+                    } else
+                    {
+                        this.EndJobWith(JobCondition.Incompletable);
+                    }
 				}
 			};
+            yield return Toils_Reserve.Release(sourceInd);
 		}
 	}
 }

--- a/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobGiver_UpdateLoadout.cs
@@ -197,7 +197,8 @@ namespace CombatExtended
 				{
 					// look for a thing inside caravan pack animals and prisoners.  EXCLUDE other colonists to avoid looping state.
 					List<Pawn> carriers = pawn.Map.mapPawns.AllPawns.Where(
-						p => p.inventory.innerContainer.Count > 0 && (p.RaceProps.packAnimal && p.Faction == pawn.Faction || p.IsPrisoner && p.HostFaction == pawn.Faction)).ToList();
+						p => p.inventory.innerContainer.Count > 0 && (p.RaceProps.packAnimal && p.Faction == pawn.Faction || p.IsPrisoner && p.HostFaction == pawn.Faction)
+                        && pawn.CanReserveAndReach(p, PathEndMode.ClosestTouch, Danger.Deadly, int.MaxValue, 0)).ToList();
 					foreach (Pawn carrier in carriers)
 					{
 						Thing thing = carrier.inventory.innerContainer.FirstOrDefault(t => findItem(t));


### PR DESCRIPTION
In order to prevent an error which could occur when multiple pawns tried to take something from a pack animal...

Also modified JobGiver to check for reservation and reachability.

Modified JobDriver to make sure that the Thing the pawn wants to take is still in it's inventory and if the stack fell below what was desired take the rest of the stack.

Also added some additional fail conditions that seemed logical.  One might be redundant...

NOTES:
 1 - Need to test if my read of ReservationManager.CanReserve is accurate and if not either set reservations down to 1 (quick change in two sections of code) or add a more detailed check for any jobs reserving the animal are NOT JobDriver_TakeFromOther as a block. (I didn't see an easy way to go from pawn to list of jobs reserving that pawn without using Harmony to access internal Reservation data.)
 2 - The check if the thing is still in the takeFrom pawn's inventory isn't cheap however it's necessary as if a pawn took a full stack of something from the animal the Thing object was transferred rather than a new Thing created (that happens most of the time) meaning that it wouldn't be in takePawn's inventory anymore.  There might be a faster way (check if the container holding the thing is the takePawn's inventory rather than a search through takeFrom's inventory for Thing).