### PR TITLE
Fixed old CR_ tradetag --> CE_

### DIFF
--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -25,8 +25,8 @@
 		<label>.56-56 Spencer rimfire cartridge</label>
 		<description>Ancient cartridge for use in the Spencer repeating rifle.</description>
 		<tradeTags>
-			<li>CR_AutoEnableTrade</li>
-			<li>CR_AutoEnableCrafting</li>
+			<li>CE_AutoEnableTrade</li>
+			<li>CE_AutoEnableCrafting</li>
 		</tradeTags>
 		<thingCategories>
 			<li>Ammo5656Spencer</li>


### PR DESCRIPTION
From Discord:

[3:04 PM] Xstamper: I also have a question, in Defs/Ammo/Rifle .56-56Spencer.xml, traderTags is CR_... so I can't make spencer ammo.
[3:05 PM] Xstamper: after changing CR to CE I can make it. Are this CR tags intentonal ones?