### PR TITLE
Fix for #278

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompFireModes.cs
@@ -159,8 +159,11 @@ namespace CombatExtended
         /// </summary>
         public void ResetModes()
         {
-            currentFireModeInt = availableFireModes.ElementAt(0);
-            currentAimModeInt = availableAimModes.ElementAt(0);
+        		//Required since availableFireModes.Capacity is set but its contents aren't so ElementAt(0) causes errors in some instances
+        	if (availableFireModes.Count > 0)
+            	currentFireModeInt = availableFireModes.ElementAt(0);
+            
+        	currentAimModeInt = availableAimModes.ElementAt(0);
         }
 
         public override IEnumerable<Gizmo> CompGetGizmosExtra()


### PR DESCRIPTION
CompFireModes.availableFireModes.ElementAt(0) caused errors if
availableFireModes.Count == 0 (by default) due to ChildrenAndPregnancy
doing some equipping/unequipping of pawns on world load