### PR TITLE
Update BodyShapes.xml (small correction)

### DIFF
--- a/Defs/Bodies/BodyShapes.xml
+++ b/Defs/Bodies/BodyShapes.xml
@@ -8,7 +8,7 @@
 	<CombatExtended.BodyShapeDef>
 		<defName>Humanoid</defName>
 		<width>0.5</width>
-		<widthLaying>0.5</widthLaying>
+		<widthLaying>1</widthLaying>
 		<height>1</height>
 		<heightLaying>0.3</heightLaying>
 	<!--<croppedTextureWidth>0.5</croppedTextureWidth>


### PR DESCRIPTION
- human bodyshapedef now causes downed humans to have double width rather than the same width