### PR TITLE
Better #358 fix

### DIFF
--- a/Source/CombatExtended/CombatExtended/CollisionVertical.cs
+++ b/Source/CombatExtended/CombatExtended/CollisionVertical.cs
@@ -49,6 +49,12 @@ namespace CombatExtended
             
             if (thing is Building)
             {
+            	var door = thing as Building_Door;
+            	if (door != null && door.Open)
+            	{
+            		return;		//returns heightRange = (0,0) & shotHeight = 0. If not open, doors have FillCategory.Full so returns (0, WallCollisionHeight)
+            	}
+            	
                 if (thing.def.Fillage == FillCategory.Full)
                 {
                     heightRange = new FloatRange(0, WallCollisionHeight);

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -601,13 +601,6 @@ namespace CombatExtended
                 if (!Rand.Chance(chance)) return false;
             }
             
-            // Doors don't collide when Building_Door.Open
-            var door = thing as Building_Door;
-            if (door != null && door.Open)
-            {
-            	return false;
-            }
-            
             var point = ShotLine.GetPoint(dist);
             if (!point.InBounds(this.Map))
             	Log.Error("TryCollideWith out of bounds point from ShotLine: obj " + thing.ThingID + ", proj " + this.ThingID + ", dist " + dist + ", point " + point);


### PR DESCRIPTION
- CollisionVertical for doors is (0,0), 0 if open, otherwise the same as
for walls
- Door code removed from ProjectileCE