### PR TITLE
Prevent the in-inventory equip functionality for nonviolent pawns

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/ITab_Inventory.cs
@@ -276,7 +276,11 @@ namespace CombatExtended
                                 {
                                     equipOptionLabel = equipOptionLabel + " " + "EquipWarningBrawler".Translate();
                                 }
-                                equipOption = new FloatMenuOption(equipOptionLabel, new Action(delegate
+                                equipOption = new FloatMenuOption(
+                                	equipOptionLabel,
+                                	(SelPawnForGear.story != null && SelPawnForGear.story.WorkTagIsDisabled(WorkTags.Violent))
+                                	? null
+                                	: new Action(delegate
                                 {
                                     compInventory.TrySwitchToWeapon(eq);
                                 }));


### PR DESCRIPTION
Action = null if pawn is nonviolent (see changes)