### PR TITLE
Power claw fix Slash -> Scratch (removed ToolCapacity Slash)

### DIFF
--- a/Defs/ToolCapacityDefs/ToolCapacity.xml
+++ b/Defs/ToolCapacityDefs/ToolCapacity.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Defs>
-
-	<ToolCapacityDef>
-		<defName>Slash</defName>
-		<label>slashing</label>
-	</ToolCapacityDef>
-
-</Defs>

--- a/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
@@ -42,7 +42,7 @@
 				<li Class="CombatExtended.ToolCE">
 					<label>claw</label>
 					<capacities>
-						<li>Slash</li>
+						<li>Scratch</li>
 					</capacities>
 					<power>15</power>
 					<cooldownTime>1.6</cooldownTime>


### PR DESCRIPTION
capacity Slash doesn't have a maneuver, but there's a maneuver called
Slash. It seems this was caused by a typo and prevented Power Claws from
being recognized as melee weapons