### PR TITLE
ArmorUtility.GetPenetrationValue revamp

### DIFF
--- a/Defs/Bodies/BodyPartGroups.xml
+++ b/Defs/Bodies/BodyPartGroups.xml
@@ -66,6 +66,11 @@
   </BodyPartGroupDef>
 
   <BodyPartGroupDef>
+    <defName>Muzzle</defName>
+    <label>muzzle</label>
+  </BodyPartGroupDef>
+
+  <BodyPartGroupDef>
     <defName>Barrels</defName>
     <label>barrels</label>
   </BodyPartGroupDef>

--- a/Patches/Core/Drugs/Drugs.xml
+++ b/Patches/Core/Drugs/Drugs.xml
@@ -50,6 +50,7 @@
           <power>8.4</power>
           <cooldownTime>1.8</cooldownTime>
           <armorPenetration>0.105</armorPenetration>
+          <linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
           <label>neck</label>

--- a/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
@@ -47,6 +47,7 @@
 					<power>15</power>
 					<cooldownTime>1.6</cooldownTime>
 					<armorPenetration>0.186</armorPenetration>
+					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 				</li>
 			</tools>
   		</value>
@@ -64,6 +65,7 @@
 					<power>20</power>
 					<cooldownTime>1.6</cooldownTime>
 					<armorPenetration>0.182</armorPenetration>
+					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>point</label>
@@ -73,6 +75,7 @@
 					<power>12</power>
 					<cooldownTime>1.6</cooldownTime>
 					<armorPenetration>0.241</armorPenetration>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 				</li>
 			</tools>
   		</value>

--- a/Patches/Core/ThingDefs_Items/Items.xml
+++ b/Patches/Core/ThingDefs_Items/Items.xml
@@ -19,18 +19,18 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>pointcut</id>
-					<label>point</label>
+					<id>edge</id>
+					<label>edge</label>
 					<capacities>
 						<li>Cut</li>
 					</capacities>
 					<power>17</power>
 					<cooldownTime>1.85</cooldownTime>
 					<armorPenetration>0.162</armorPenetration>
-					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>pointstab</id>
+					<id>point</id>
 					<label>point</label>
 					<capacities>
 						<li>Stab</li>
@@ -78,18 +78,18 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>pointcut</id>
-					<label>point</label>
+					<id>edge</id>
+					<label>edge</label>
 					<capacities>
 						<li>Cut</li>
 					</capacities>
 					<power>20</power>
 					<cooldownTime>2.5</cooldownTime>
 					<armorPenetration>0.182</armorPenetration>
-					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>pointstab</id>
+					<id>point</id>
 					<label>point</label>
 					<capacities>
 						<li>Stab</li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -78,14 +78,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>8</power>
           <cooldownTime>1.6</cooldownTime>
           <armorPenetration>0.075</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -162,14 +162,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>8</power>
           <cooldownTime>1.6</cooldownTime>
           <armorPenetration>0.075</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -243,14 +243,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
           <armorPenetration>0.086</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -325,14 +325,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
           <armorPenetration>0.086</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -408,14 +408,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
           <armorPenetration>0.086</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -496,14 +496,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
           <armorPenetration>0.086</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -579,14 +579,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
           <armorPenetration>0.086</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -667,14 +667,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>8</power>
           <cooldownTime>1.6</cooldownTime>
           <armorPenetration>0.075</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -755,14 +755,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>8</power>
           <cooldownTime>1.6</cooldownTime>
           <armorPenetration>0.075</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -846,14 +846,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
           <armorPenetration>0.086</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -939,14 +939,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
           <armorPenetration>0.086</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -1028,14 +1028,14 @@
         </li>
         <li Class="CombatExtended.ToolCE">
         	<id>barrelpoke</id>
-          <label>barrel</label>
+          <label>muzzle</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>10</power>
           <cooldownTime>1.9</cooldownTime>
           <armorPenetration>0.086</armorPenetration>
-          <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+          <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Melee.xml
@@ -433,14 +433,14 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<id>shaftpoke</id>
-					<label>shaft</label>
+					<label>point</label>
 					<capacities>
 						<li>Poke</li>
 					</capacities>
 					<power>6</power>
 					<cooldownTime>1.02</cooldownTime>
 					<armorPenetration>0.064</armorPenetration>
-					<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
@@ -505,14 +505,14 @@
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<id>shaftpoke</id>
-					<label>shaft</label>
+					<label>point</label>
 					<capacities>
 						<li>Poke</li>
 					</capacities>
 					<power>8</power>
 					<cooldownTime>1.15</cooldownTime>
 					<armorPenetration>0.075</armorPenetration>
-					<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
+					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>

--- a/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -37,22 +37,26 @@
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">
-          <id>bowlimbblunt</id>
+          <id>limb</id>
+		  <label>limb</label>
           <capacities>
             <li>Blunt</li>
           </capacities>
           <power>8</power>
           <cooldownTime>1.6</cooldownTime>
           <armorPenetration>0.102</armorPenetration>
+			<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>bowlimbpoke</id>
+          <id>nock</id>
+		  <label>nock</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>8</power>
           <cooldownTime>1.6</cooldownTime>
           <armorPenetration>0.075</armorPenetration>
+			<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -95,22 +99,26 @@
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">
-          <id>bowlimbblunt</id>
+          <id>limb</id>
+		  <label>limb</label>
           <capacities>
             <li>Blunt</li>
           </capacities>
           <power>8</power>
           <cooldownTime>1.6</cooldownTime>
           <armorPenetration>0.102</armorPenetration>
+			<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>bowlimbpoke</id>
+          <id>nock</id>
+		  <label>nock</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>8</power>
           <cooldownTime>1.6</cooldownTime>
           <armorPenetration>0.075</armorPenetration>
+			<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>
@@ -153,22 +161,26 @@
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">
-          <id>bowlimbblunt</id>
+          <id>limb</id>
+		  <label>limb</label>
           <capacities>
             <li>Blunt</li>
           </capacities>
           <power>8</power>
           <cooldownTime>1.6</cooldownTime>
           <armorPenetration>0.102</armorPenetration>
+			<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>bowlimbpoke</id>
+          <id>nock</id>
+		  <label>nock</label>
           <capacities>
             <li>Poke</li>
           </capacities>
           <power>8</power>
           <cooldownTime>1.6</cooldownTime>
           <armorPenetration>0.075</armorPenetration>
+			<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
         </li>
       </tools>
     </value>

--- a/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Medival.xml
+++ b/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Medival.xml
@@ -42,22 +42,26 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<id>bowlimbblunt</id>
+							<id>limb</id>
+							<label>limb</label>
 							<capacities>
 								<li>Blunt</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.102</armorPenetration>
+							<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>bowlimbpoke</id>
+							<id>nock</id>
+							<label>nock</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
+							<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Modern.xml
+++ b/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Modern.xml
@@ -75,14 +75,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -154,14 +154,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -235,14 +235,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -314,14 +314,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -393,14 +393,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -473,14 +473,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -553,14 +553,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -633,14 +633,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -714,14 +714,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -793,7 +793,7 @@
 							<cooldownTime>1.6</cooldownTime>
 							<commonality>1.5</commonality>
 							<armorPenetration>0.102</armorPenetration>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Magazine</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelblunt</id>
@@ -808,14 +808,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -888,7 +888,7 @@
 							<cooldownTime>1.6</cooldownTime>
 							<commonality>1.5</commonality>
 							<armorPenetration>0.102</armorPenetration>
-							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Magazine</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelblunt</id>
@@ -903,14 +903,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -998,14 +998,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1093,14 +1093,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1189,14 +1189,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1284,14 +1284,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1368,14 +1368,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>12</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1450,14 +1450,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1529,14 +1529,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1609,14 +1609,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1690,14 +1690,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1771,14 +1771,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1853,14 +1853,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -1935,14 +1935,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2016,14 +2016,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2100,14 +2100,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2183,14 +2183,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2265,14 +2265,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2345,14 +2345,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2424,14 +2424,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2504,14 +2504,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2583,14 +2583,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2652,14 +2652,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2721,14 +2721,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2789,14 +2789,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -2857,14 +2857,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -3001,14 +3001,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -3083,14 +3083,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -3165,14 +3165,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -3235,14 +3235,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -3304,14 +3304,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -3373,14 +3373,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>

--- a/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Spacer.xml
+++ b/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Spacer.xml
@@ -68,14 +68,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -144,14 +144,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>8</power>
 							<cooldownTime>1.6</cooldownTime>
 							<armorPenetration>0.075</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -216,14 +216,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>
@@ -290,14 +290,14 @@
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<id>barrelpoke</id>
-							<label>barrel</label>
+							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
 							</capacities>
 							<power>10</power>
 							<cooldownTime>1.9</cooldownTime>
 							<armorPenetration>0.086</armorPenetration>
-							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
 						</li>
 					</tools>
 				</value>

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -217,12 +217,13 @@ namespace CombatExtended
         {
             float damAmount = (float)this.verbProps.AdjustedMeleeDamageAmount(this, base.CasterPawn, this.ownerEquipment);
             var critDamDef = CritDamageDef;
-            DamageDef damDef = isCrit && critDamDef != DamageDefOf.Stun ? critDamDef : verbProps.meleeDamageDef;
-            BodyPartGroupDef bodyPartGroupDef = tool?.linkedBodyPartsGroup;
+            DamageDef damDef = isCrit && critDamDef != DamageDefOf.Stun ? critDamDef : verbProps.meleeDamageDef;	//Added isCrit check
+            BodyPartGroupDef bodyPartGroupDef = null;
             HediffDef hediffDef = null;
             damAmount = UnityEngine.Random.Range(damAmount * 0.8f, damAmount * 1.2f);
             if (base.CasterIsPawn)
             {
+            	bodyPartGroupDef = LinkedBodyPartsGroup;
                 if (damAmount >= 1f)
                 {
                     if (this.ownerHediffComp != null)


### PR DESCRIPTION
- GetUsedTool(tools, dinfo) to get the tool specified in dinfo. Contains
a lot of error logging whenever it can't find the exact tool used.
- IsWeapon -> IsMeleeWeapon check (this previously caused errors on
meleeing with ranged weapons)
- More error logging for augments and natural tools, to make sure the
XML gets updated at some point such that the method is able to
differentiate between tools