### PR TITLE
Roof explosions

### DIFF
--- a/Defs/ThingDefs_Misc/Ethereal_Various.xml
+++ b/Defs/ThingDefs_Misc/Ethereal_Various.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+	<ThingDef Abstract="True" Name="EtherealThingBase">
+		<category>Ethereal</category>
+		<useHitPoints>false</useHitPoints>
+		<drawerType>None</drawerType>
+	</ThingDef>
+
+	<ThingDef ParentName="EtherealThingBase">
+		<defName>ExplosionCE</defName>
+		<label>explosion</label>
+		<thingClass>CombatExtended.ExplosionCE</thingClass>
+		<tickerType>Normal</tickerType>
+	</ThingDef>
+
+</Defs>

--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -139,6 +139,7 @@
     <Compile Include="CombatExtended\Defs\LoadoutGenericDef.cs" />
     <Compile Include="CombatExtended\Defs\RacePropertiesExtensionCE.cs" />
     <Compile Include="CombatExtended\Enums\LoadoutCountType.cs" />
+    <Compile Include="CombatExtended\ExplosionCE.cs" />
     <Compile Include="CombatExtended\Jobs\JobDriver_Hunt.cs" />
     <Compile Include="CombatExtended\Jobs\JobDriver_Stabilize.cs" />
     <Compile Include="CombatExtended\Jobs\JobDriver_TakeFromOther.cs" />

--- a/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
@@ -43,18 +43,17 @@ namespace CombatExtended
                 return;
             }
 			
-            // Fragmentation stuff
-            if (!Props.fragments.NullOrEmpty() && GenGrid.InBounds(posIV, map))
+            var projCE = parent as ProjectileCE;
+            
+            #region Fragmentation
+            if (!Props.fragments.NullOrEmpty())
             {
-            	
                 float edificeHeight = (new CollisionVertical(posIV.GetEdifice(map))).Max;
                 Vector2 exactOrigin = new Vector2(pos.x, pos.z);
                 float height;
                 
                 //Fragments fly from a 0 to 45 degree angle away from the explosion
                 var range = new FloatRange(0, Mathf.PI / 8f);
-                
-                var projCE = parent as ProjectileCE;
                 
                 if (projCE != null)
                 {
@@ -68,6 +67,7 @@ namespace CombatExtended
                 }
                 else
                 {
+                	//Height is not tracked on non-CE projectiles, so we assume this one's on top of the edifice
                 	height = edificeHeight;
                 }
                 
@@ -95,18 +95,20 @@ namespace CombatExtended
                     }
                 }
             }
+            #endregion
+            
             // Regular explosion stuff
             if (Props.explosionRadius > 0 && Props.explosionDamage > 0 && parent.def != null && GenGrid.InBounds(posIV, map))
             {
-                // Can't use GenExplosion because it no longer allows setting damage amount
-
                 // Copy-paste from GenExplosion
-                Explosion explosion = (Explosion)GenSpawn.Spawn(ThingDefOf.Explosion, posIV, map);
+                ExplosionCE explosion = GenSpawn.Spawn(CE_ThingDefOf.ExplosionCE, posIV, map) as ExplosionCE;
+                explosion.height = pos.y;
                 explosion.radius = Props.explosionRadius * scaleFactor;
                 explosion.damType = Props.explosionDamageDef;
                 explosion.instigator = instigator;
                 explosion.damAmount = GenMath.RoundRandom(Props.explosionDamage * scaleFactor);
                 explosion.weapon = null;
+                explosion.projectile = parent.def;
                 explosion.preExplosionSpawnThingDef = Props.preExplosionSpawnThingDef;
                 explosion.preExplosionSpawnChance = Props.preExplosionSpawnChance;
                 explosion.preExplosionSpawnThingCount = Props.preExplosionSpawnThingCount;
@@ -114,6 +116,8 @@ namespace CombatExtended
                 explosion.postExplosionSpawnChance = Props.postExplosionSpawnChance;
                 explosion.postExplosionSpawnThingCount = Props.postExplosionSpawnThingCount;
                 explosion.applyDamageToExplosionCellsNeighbors = Props.applyDamageToExplosionCellsNeighbors;
+                explosion.chanceToStartFire = parent.def.projectile.explosionChanceToStartFire;
+                explosion.dealMoreDamageAtCenter = parent.def.projectile.explosionDealMoreDamageAtCenter;
                 explosion.StartExplosion(Props.explosionDamageDef.soundExplosion);
             }
         }

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_ThingDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_ThingDefOf.cs
@@ -14,6 +14,7 @@ namespace CombatExtended
         public static readonly ThingDef Mote_HunkerIcon = ThingDef.Named("Mote_HunkerIcon");
 
         public static ThingDef FSX;
+        public static ThingDef ExplosionCE;
 
         public static ThingDef AmmoBench;
         public static ThingDef FilthPrometheum;

--- a/Source/CombatExtended/CombatExtended/ExplosionCE.cs
+++ b/Source/CombatExtended/CombatExtended/ExplosionCE.cs
@@ -1,0 +1,255 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Verse;
+using Verse.Sound;
+
+namespace CombatExtended
+{
+	public class ExplosionCE : Explosion
+	{
+		public float height;
+
+		private int startTick;
+		private List<IntVec3> cellsToAffect;
+		private List<Thing> damagedThings;
+		private HashSet<IntVec3> addedCellsAffectedOnlyByDamage;
+		private const float DamageFactorAtEdge = 0.2f;
+		private static HashSet<IntVec3> tmpCells = new HashSet<IntVec3>();
+
+		public override void SpawnSetup(Map map, bool respawningAfterLoad)
+		{
+			base.SpawnSetup(map, respawningAfterLoad);
+			if (!respawningAfterLoad) {
+				this.cellsToAffect = SimplePool<List<IntVec3>>.Get();
+				this.cellsToAffect.Clear();
+				this.damagedThings = SimplePool<List<Thing>>.Get();
+				this.damagedThings.Clear();
+				this.addedCellsAffectedOnlyByDamage = SimplePool<HashSet<IntVec3>>.Get();
+				this.addedCellsAffectedOnlyByDamage.Clear();
+			}
+		}
+
+		public override void DeSpawn()
+		{
+			base.DeSpawn();
+			this.cellsToAffect.Clear();
+			SimplePool<List<IntVec3>>.Return(this.cellsToAffect);
+			this.cellsToAffect = null;
+			this.damagedThings.Clear();
+			SimplePool<List<Thing>>.Return(this.damagedThings);
+			this.damagedThings = null;
+			this.addedCellsAffectedOnlyByDamage.Clear();
+			SimplePool<HashSet<IntVec3>>.Return(this.addedCellsAffectedOnlyByDamage);
+			this.addedCellsAffectedOnlyByDamage = null;
+		}
+
+		public virtual IEnumerable<IntVec3> ExplosionCellsToHit
+		{
+			get
+			{
+				bool roofed = Position.Roofed(Map);
+				bool aboveRoofs = height >= CollisionVertical.WallCollisionHeight;
+				
+				var openCells = new List<IntVec3>();
+				var adjWallCells = new List<IntVec3>();
+				
+				int num = GenRadial.NumCellsInRadius(radius);
+				for (int i = 0; i < num; i++)
+				{
+					IntVec3 intVec = Position + GenRadial.RadialPattern[i];
+					if (intVec.InBounds(Map))
+					{
+						if (aboveRoofs)
+						{
+							if ((!roofed && GenSight.LineOfSight(Position, intVec, Map, false, null, 0, 0))
+							   || !intVec.Roofed(Map))
+							{
+								openCells.Add(intVec);
+							}
+						}
+						else if (GenSight.LineOfSight(Position, intVec, Map, true, null, 0, 0))
+						{
+							openCells.Add(intVec);
+						}
+					}
+				}
+				foreach (var intVec2 in openCells) {
+					if (intVec2.Walkable(Map)) {
+						for (int k = 0; k < 4; k++) {
+							IntVec3 intVec3 = intVec2 + GenAdj.CardinalDirections[k];
+							if (intVec3.InHorDistOf(Position, radius)) {
+								if (intVec3.InBounds(Map)) {
+									if (!intVec3.Standable(Map)) {
+										if (intVec3.GetEdifice(Map) != null) {
+											if (!openCells.Contains(intVec3) && adjWallCells.Contains(intVec3)) {
+												adjWallCells.Add(intVec3);
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				return openCells.Concat(adjWallCells);
+			}
+		}
+		
+		public override void StartExplosion(SoundDef explosionSound)
+		{
+			if (!base.Spawned) {
+				Log.Error("Called StartExplosion() on unspawned thing.");
+				return;
+			}
+			this.startTick = Find.TickManager.TicksGame;
+			this.cellsToAffect.Clear();
+			this.damagedThings.Clear();
+			this.addedCellsAffectedOnlyByDamage.Clear();
+			//this.cellsToAffect.AddRange(this.damType.Worker.ExplosionCellsToHit(this));
+			this.cellsToAffect.AddRange(this.ExplosionCellsToHit);
+			if (this.applyDamageToExplosionCellsNeighbors) {
+				this.AddCellsNeighbors(this.cellsToAffect);
+			}
+			this.damType.Worker.ExplosionStart(this, this.cellsToAffect);
+			this.PlayExplosionSound(explosionSound);
+			MoteMaker.MakeWaterSplash(base.Position.ToVector3Shifted(), base.Map, this.radius * 6f, 20f);
+			this.cellsToAffect.Sort((IntVec3 a, IntVec3 b) => this.GetCellAffectTick(b).CompareTo(this.GetCellAffectTick(a)));
+			RegionTraverser.BreadthFirstTraverse(base.Position, base.Map, (Region from, Region to) => true, delegate(Region x) {
+				List<Thing> list = x.ListerThings.ThingsInGroup(ThingRequestGroup.Pawn);
+				for (int i = list.Count - 1; i >= 0; i--) {
+					((Pawn)list[i]).mindState.Notify_Explosion(this);
+				}
+				return false;
+			}, 25, RegionType.Set_Passable);
+		}
+
+		public override void Tick()
+		{
+			int ticksGame = Find.TickManager.TicksGame;
+			int count = this.cellsToAffect.Count;
+			for (int i = count - 1; i >= 0; i--) {
+				if (ticksGame < this.GetCellAffectTick(this.cellsToAffect[i])) {
+					break;
+				}
+				try {
+					this.AffectCell(this.cellsToAffect[i]);
+				}
+				catch (Exception ex) {
+					Log.Error(string.Concat(new object[] {
+						"Explosion could not affect cell ",
+						this.cellsToAffect[i],
+						": ",
+						ex
+					}));
+				}
+				this.cellsToAffect.RemoveAt(i);
+			}
+			if (!this.cellsToAffect.Any<IntVec3>()) {
+				this.Destroy(DestroyMode.Vanish);
+			}
+		}
+
+		public override void ExposeData()
+		{
+			base.ExposeData();
+			Scribe_Values.Look<int>(ref this.startTick, "startTick", 0, false);
+			Scribe_Collections.Look<IntVec3>(ref this.cellsToAffect, "cellsToAffect", LookMode.Value, new object[0]);
+			Scribe_Collections.Look<Thing>(ref this.damagedThings, "damagedThings", LookMode.Reference, new object[0]);
+			Scribe_Collections.Look<IntVec3>(ref this.addedCellsAffectedOnlyByDamage, "addedCellsAffectedOnlyByDamage", LookMode.Value);
+			if (Scribe.mode == LoadSaveMode.PostLoadInit) {
+				this.damagedThings.RemoveAll((Thing x) => x == null);
+			}
+		}
+
+		private int GetCellAffectTick(IntVec3 cell)
+		{
+			return this.startTick + (int)((cell - base.Position).LengthHorizontal * 1.5f);
+		}
+
+		private void AffectCell(IntVec3 c)
+		{
+			bool flag = this.ShouldCellBeAffectedOnlyByDamage(c);
+			if (!flag && Rand.Chance(this.preExplosionSpawnChance) && c.Walkable(base.Map)) {
+				this.TrySpawnExplosionThing(this.preExplosionSpawnThingDef, c, this.preExplosionSpawnThingCount);
+			}
+			this.damType.Worker.ExplosionAffectCell(this, c, this.damagedThings, !flag);
+			if (!flag && Rand.Chance(this.postExplosionSpawnChance) && c.Walkable(base.Map)) {
+				this.TrySpawnExplosionThing(this.postExplosionSpawnThingDef, c, this.postExplosionSpawnThingCount);
+			}
+			float num = this.chanceToStartFire;
+			if (this.dealMoreDamageAtCenter) {
+				num *= Mathf.Lerp(1f, 0.2f, c.DistanceTo(base.Position) / this.radius);
+			}
+			if (Rand.Chance(num)) {
+				FireUtility.TryStartFireIn(c, base.Map, Rand.Range(0.1f, 0.925f));
+			}
+		}
+
+		private void TrySpawnExplosionThing(ThingDef thingDef, IntVec3 c, int count)
+		{
+			if (thingDef == null) {
+				return;
+			}
+			if (thingDef.IsFilth) {
+				FilthMaker.MakeFilth(c, base.Map, thingDef, count);
+			}
+			else {
+				Thing thing = ThingMaker.MakeThing(thingDef, null);
+				thing.stackCount = count;
+				GenSpawn.Spawn(thing, c, base.Map);
+			}
+		}
+
+		private void PlayExplosionSound(SoundDef explosionSound)
+		{
+			bool flag;
+			if (Prefs.DevMode) {
+				flag = (explosionSound != null);
+			}
+			else {
+				flag = !explosionSound.NullOrUndefined();
+			}
+			if (flag) {
+				explosionSound.PlayOneShot(new TargetInfo(base.Position, base.Map, false));
+			}
+			else {
+				this.damType.soundExplosion.PlayOneShot(new TargetInfo(base.Position, base.Map, false));
+			}
+		}
+
+		private void AddCellsNeighbors(List<IntVec3> cells)
+		{
+			ExplosionCE.tmpCells.Clear();
+			this.addedCellsAffectedOnlyByDamage.Clear();
+			for (int i = 0; i < cells.Count; i++) {
+				ExplosionCE.tmpCells.Add(cells[i]);
+			}
+			for (int j = 0; j < cells.Count; j++) {
+				if (cells[j].Walkable(base.Map)) {
+					for (int k = 0; k < GenAdj.AdjacentCells.Length; k++) {
+						IntVec3 intVec = cells[j] + GenAdj.AdjacentCells[k];
+						if (intVec.InBounds(base.Map)) {
+							bool flag = ExplosionCE.tmpCells.Add(intVec);
+							if (flag) {
+								this.addedCellsAffectedOnlyByDamage.Add(intVec);
+							}
+						}
+					}
+				}
+			}
+			cells.Clear();
+			foreach (IntVec3 current in ExplosionCE.tmpCells) {
+				cells.Add(current);
+			}
+			ExplosionCE.tmpCells.Clear();
+		}
+
+		private bool ShouldCellBeAffectedOnlyByDamage(IntVec3 c)
+		{
+			return this.applyDamageToExplosionCellsNeighbors && this.addedCellsAffectedOnlyByDamage.Contains(c);
+		}
+	}
+}

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE_Explosive.cs
@@ -1,5 +1,6 @@
 using System;
 using Verse;
+using RimWorld;
 using UnityEngine;
 
 namespace CombatExtended
@@ -27,38 +28,35 @@ namespace CombatExtended
         }
         protected override void Impact(Thing hitThing)
         {
-            if (this.def.projectile.explosionDelay == 0)
+            if (def.projectile.explosionDelay == 0)
             {
-                this.Explode();
+                Explode();
                 return;
             }
-            this.landed = true;
-            this.ticksToDetonation = this.def.projectile.explosionDelay;
+            landed = true;
+            ticksToDetonation = def.projectile.explosionDelay;
             GenExplosion.NotifyNearbyPawnsOfDangerousExplosive(this, this.def.projectile.damageDef, this.launcher?.Faction);
         }
         protected virtual void Explode()
         {
-            Map map = base.Map;
-            //this.Destroy(DestroyMode.Vanish);
-            ProjectilePropertiesCE propsCE = def.projectile as ProjectilePropertiesCE;
-            GenExplosion.DoExplosion(ExactPosition.ToIntVec3(), 
-                map,
-                def.projectile.explosionRadius,
-                def.projectile.damageDef, 
-                launcher,
-                def.projectile.damageAmountBase,
-                def.projectile.soundExplode, 
-                equipmentDef, 
-                def,
-                def.projectile.postExplosionSpawnThingDef,
-                def.projectile.postExplosionSpawnChance,
-                def.projectile.postExplosionSpawnThingCount, 
-                def.projectile.applyDamageToExplosionCellsNeighbors,
-                def.projectile.preExplosionSpawnThingDef, 
-                def.projectile.preExplosionSpawnChance, 
-                def.projectile.preExplosionSpawnThingCount, 
-                def.projectile.explosionChanceToStartFire, 
-                def.projectile.explosionDealMoreDamageAtCenter);
+            ExplosionCE explosion = GenSpawn.Spawn(CE_ThingDefOf.ExplosionCE, ExactPosition.ToIntVec3(), Map) as ExplosionCE;
+            explosion.height = ExactPosition.y;
+            explosion.radius = def.projectile.explosionRadius;
+            explosion.damType = def.projectile.damageDef;
+            explosion.instigator = launcher;
+            explosion.damAmount = def.projectile.damageAmountBase;
+            explosion.weapon = equipmentDef;
+            explosion.projectile = def;
+            explosion.preExplosionSpawnThingDef = def.projectile.preExplosionSpawnThingDef;
+            explosion.preExplosionSpawnChance = def.projectile.preExplosionSpawnChance;
+            explosion.preExplosionSpawnThingCount = def.projectile.preExplosionSpawnThingCount;
+            explosion.postExplosionSpawnThingDef = def.projectile.postExplosionSpawnThingDef;
+            explosion.postExplosionSpawnChance = def.projectile.postExplosionSpawnChance;
+            explosion.postExplosionSpawnThingCount = def.projectile.postExplosionSpawnThingCount;
+            explosion.applyDamageToExplosionCellsNeighbors = def.projectile.applyDamageToExplosionCellsNeighbors;
+            explosion.chanceToStartFire = def.projectile.explosionChanceToStartFire;
+            explosion.dealMoreDamageAtCenter = def.projectile.explosionDealMoreDamageAtCenter;
+            explosion.StartExplosion(def.projectile.soundExplode);
 
             //This code was disabled because it didn't run under previous circumstances. Could be enabled if necessary
             /*
@@ -71,7 +69,7 @@ namespace CombatExtended
             base.Impact(null); // base.Impact() handles this.Destroy() and comp.Explode()
         }
 
-        public static void ThrowBigExplode(Vector3 loc, Map map, float size)
+      /*public static void ThrowBigExplode(Vector3 loc, Map map, float size)
         {
             if (!loc.ShouldSpawnMotesAt(map))
             {
@@ -83,6 +81,6 @@ namespace CombatExtended
             moteThrown.exactPosition = loc;
             moteThrown.SetVelocity((float)Rand.Range(6, 8), Rand.Range(0.002f, 0.003f));
             GenSpawn.Spawn(moteThrown, loc.ToIntVec3(), map);
-        }
+        }*/
     }
 }


### PR DESCRIPTION
Additionally fixes #423 BUG: Vanilla explosions will always occur on the cells below the roof, even if the explosive landed on top of the roof. This should be changed.