### PR TITLE
Fix loadout all ammo for gun setting

### DIFF
--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutGenericDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutGenericDef.cs
@@ -124,8 +124,8 @@ namespace CombatExtended
 				generic.defaultCount = gun.GetCompProperties<CompProperties_AmmoUser>().magazineSize;
 				generic.defaultCountType = LoadoutCountType.pickupDrop; // we want ammo to get picked up.
 				//generic._lambda = td => td is AmmoDef && gun.GetCompProperties<CompProperties_AmmoUser>().ammoSet.ammoTypes.Contains(td);
-				generic.thingRequestGroup = ThingRequestGroup.Shell;
-				generic._lambda = td => gun.GetCompProperties<CompProperties_AmmoUser>().ammoSet.ammoTypes.Any(al => al.ammo == td);
+				generic.thingRequestGroup = ThingRequestGroup.HaulableEver;
+				generic._lambda = td => td is AmmoDef && gun.GetCompProperties<CompProperties_AmmoUser>().ammoSet.ammoTypes.Any(al => al.ammo == td);
 				defs.Add(generic);
 				//Log.Message(string.Concat("CombatExtended :: LoadoutGenericDef :: ", generic.LabelCap, " list: ", string.Join(", ", DefDatabase<ThingDef>.AllDefs.Where(t => generic.lambda(t)).Select(t => t.label).ToArray())));
 			}


### PR DESCRIPTION
currently it lead to: 
Exception filling window for CombatExtended.Dialog_ManageLoadouts: System.InvalidOperationException: Operation is not valid due to the current state of the object
  at System.Linq.Enumerable.Iterate[ThingDef,Single] (IEnumerable1 source, Single initValue, System.Func3 selector) [0x00000] in <filename unknown>:0 
  at System.Linq.Enumerable.Max[ThingDef] (IEnumerable1 source, System.Func2 selector) [0x00000] in <filename unknown>:0 
  at CombatExtended.LoadoutGenericDef.updateVars () [0x00000] in <filename unknown>:0 
  at CombatExtended.LoadoutGenericDef.get_mass () [0x00000] in <filename unknown>:0 
  at CombatExtended.Utility_Loadouts.GetWeightAndBulkTip (CombatExtended.LoadoutGenericDef def, Int32 count) [0x00000] in <filename unknown>:0 
  at CombatExtended.Dialog_ManageLoadouts.DrawSlot (Rect row, CombatExtended.LoadoutSlot slot, Boolean slotDraggable) [0x00000] in <filename unknown>:0 
  at CombatExtended.Dialog_ManageLoadouts.DrawSlotList (Rect canvas) [0x00000] in <filename unknown>:0 
  at CombatExtended.Dialog_ManageLoadouts.DoWindowContents (Rect canvas) [0x00000] in <filename unknown>:0 
  at Verse.Window+<WindowOnGUI>cAnonStorey0.<>m0 (Int32 x) [0x00000] in <filename unknown>:0 
Verse.Log:Error(String)
Verse.<WindowOnGUI>cAnonStorey0:<>m0(Int32)
UnityEngine.GUI:CallWindowDelegate(WindowFunction, Int32, Int32, GUISkin, Int32, Single, Single, GUIStyle)