### PR TITLE
Tw

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -104,6 +104,7 @@
       <armorPenetration>0.35</armorPenetration>
       <pelletCount>9</pelletCount>
       <spreadMult>17.8</spreadMult>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 
@@ -119,6 +120,7 @@
         </li>
       </secondaryDamage>
       <armorPenetration>0.6</armorPenetration>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -66,6 +66,7 @@
         </li>
       </secondaryDamage>
       <armorPenetration>1.2</armorPenetration>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -52,6 +52,7 @@
 			<damageDef>Bullet</damageDef>
 			<speed>112</speed>
 			<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
+            <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -89,6 +89,7 @@
     <projectile>
       <speed>40</speed>
       <flyOverhead>false</flyOverhead>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -66,6 +66,7 @@
         </li>
       </secondaryDamage>
       <armorPenetration>0.95</armorPenetration>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/Advanced/60x225mmGammaShell.xml
+++ b/Defs/Ammo/Advanced/60x225mmGammaShell.xml
@@ -74,6 +74,7 @@
       <soundHitThickRoof>ArtilleryHitThickRoof</soundHitThickRoof>
       <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
       <soundAmbient>MortarRound_Ambient</soundAmbient>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/Advanced/6x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x18mmCharged.xml
@@ -102,6 +102,7 @@
         </li>
       </secondaryDamage>
       <armorPenetration>0.5</armorPenetration>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 
@@ -117,6 +118,7 @@
         </li>
       </secondaryDamage>
       <armorPenetration>0.6</armorPenetration>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -102,6 +102,7 @@
         </li>
       </secondaryDamage>
       <armorPenetration>0.65</armorPenetration>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 
@@ -117,6 +118,7 @@
         </li>
       </secondaryDamage>
       <armorPenetration>0.8</armorPenetration>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
+++ b/Defs/Ammo/Advanced/70mmMechanoidGrenade.xml
@@ -84,6 +84,7 @@
 		</graphicData>
 		<projectile>
 			<speed>50</speed>
+            <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -78,6 +78,7 @@
       <soundHitThickRoof>ArtilleryHitThickRoof</soundHitThickRoof>
       <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
       <soundAmbient>MortarRound_Ambient</soundAmbient>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -102,6 +102,7 @@
         </li>
       </secondaryDamage>
       <armorPenetration>0.8</armorPenetration>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 
@@ -117,6 +118,7 @@
         </li>
       </secondaryDamage>
       <armorPenetration>1.0</armorPenetration>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/AmmoBases.xml
+++ b/Defs/Ammo/AmmoBases.xml
@@ -77,6 +77,7 @@
 	<ThingDef Name="BaseFragment" ParentName="BaseBullet" Abstract="True">
 	<projectile>
 		<alwaysFreeIntercept>true</alwaysFreeIntercept>
+		<allowPenetrateTrough>false</allowPenetrateTrough>
 	</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Advanced.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Advanced.xml
@@ -25,6 +25,7 @@
     <defName>IncendiaryFuel</defName>
     <label>incendiary</label>
     <description>Filled with incendiary agent that ignites after impact.</description>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
 
    <CombatExtended.AmmoCategoryDef>
@@ -32,6 +33,7 @@
     <label>thermobaric</label>
     <description>Filled with high-explosive aerosol that causes a large explosion and ignites flammable materials.</description>
 	<advanced>true</advanced>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
 
    <CombatExtended.AmmoCategoryDef>
@@ -39,6 +41,7 @@
     <label>foam</label>
     <description>Special round designed for civilian fire-fighting purposes. Filled with fire-retardant foam to suppress fires in a large area.</description>
 	<advanced>true</advanced>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
 
   <!-- ========== For Vanilla-Friendly Weapons Expansion ========== -->

--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_General.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_General.xml
@@ -20,6 +20,7 @@
     <label>hollow point</label>
     <labelShort>HP</labelShort>
     <description>A hollowed out tip causes the bullet to expand on impact, increasing tissue damage at the cost of armor penetration.</description>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
 
   <CombatExtended.AmmoCategoryDef>
@@ -34,6 +35,7 @@
     <label>armor-piercing incendiary</label>
     <labelShort>AP-I</labelShort>
     <description>Filled with an incendiary compound that ignites on impact, doing additional damage and increasing armor penetration.</description>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
 
   <CombatExtended.AmmoCategoryDef>
@@ -42,6 +44,7 @@
     <labelShort>AP-HE</labelShort>
     <description>Filled with high-explosives that detonate on impact for additional damage.</description>
     <advanced>true</advanced>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
   
 </Defs>

--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Grenades.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Grenades.xml
@@ -6,6 +6,7 @@
     <label>high-explosive</label>
     <labelShort>HE</labelShort>
     <description>The high-explosive charge detonates on impact, scattering lethal shell fragments in a large area.</description>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
 
    <CombatExtended.AmmoCategoryDef>
@@ -13,6 +14,7 @@
     <label>EMP</label>
     <description>Creates an electro-magnetic burst on impact, temporarily disrupting electronic systems and Mechanoids.</description>
 	<advanced>true</advanced>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
 
    <CombatExtended.AmmoCategoryDef>
@@ -20,6 +22,7 @@
     <label>Incendiary</label>
     <description>Filled with incendiary agent. The agent is dispersed on impact, covering the area in flames.</description>
 	<advanced>true</advanced>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
   
 </Defs>

--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Neolithic.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Neolithic.xml
@@ -36,6 +36,7 @@
 		<label>stone sling bullet</label>
     <labelShort>stone</labelShort>
 		<description>A streamlined stone designed to fly far and hit hard. Not particularly effective against armor.</description>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
 	</CombatExtended.AmmoCategoryDef>
 
 	<CombatExtended.AmmoCategoryDef>
@@ -44,6 +45,7 @@
     <labelShort>steel</labelShort>
 		<description>A refined sling bullet made out of steel to enhance armor penetration.</description>
 		<advanced>true</advanced>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
 	</CombatExtended.AmmoCategoryDef>
 
 	<CombatExtended.AmmoCategoryDef>
@@ -52,6 +54,7 @@
     <labelShort>plasteel</labelShort>
 		<description>A highly-refined sling bullet made out of plasteel to maximize penetration.</description>
 		<advanced>true</advanced>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
 	</CombatExtended.AmmoCategoryDef>
 
 	<CombatExtended.AmmoCategoryDef>

--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Rockets.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Rockets.xml
@@ -6,6 +6,7 @@
     <label>high-explosive anti-tank</label>
     <labelShort>HEAT</labelShort>
     <description>Shaped charge warhead. Detonates on impact, creating a super-heated stream of molten metal that punches through enemy armor.</description>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
 
    <CombatExtended.AmmoCategoryDef>
@@ -13,6 +14,7 @@
     <label>thermobaric</label>
     <description>Disperses and subsequently ignites a fuel-air explosive mix, creating a powerful explosion and potentially igniting flammable objects.</description>
 	<advanced>true</advanced>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
 
    <CombatExtended.AmmoCategoryDef>
@@ -20,6 +22,7 @@
     <label>fragmentation</label>
     <labelShort>Frag</labelShort>
     <description>Designed to explode into a cloud of deadly shrapnel, shredding soft targets in a large area.</description>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
   
 </Defs>

--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Shotgun.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Shotgun.xml
@@ -26,6 +26,7 @@
     <label>beanbag</label>
     <labelShort>bean</labelShort>
     <description>Non-lethal rubber round originally designed for riot control. Accurate over short ranges only. Designed to temporarily incapacitate a target, it does not cause bleeding or damage to internal organs.</description>
+	<allowPenetrateTrough>false</allowPenetrateTrough>
   </CombatExtended.AmmoCategoryDef>
 
    <CombatExtended.AmmoCategoryDef>

--- a/Defs/Ammo/Grenade/25x40mmGrenade.xml
+++ b/Defs/Ammo/Grenade/25x40mmGrenade.xml
@@ -93,6 +93,7 @@
 		</graphicData>
 		<projectile>
 			<speed>84</speed>
+            <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>
 		

--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -95,6 +95,7 @@
 		<projectile>
 			<speed>60</speed>
 			<flyOverhead>false</flyOverhead>
+           <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -94,6 +94,7 @@
 		</graphicData>
 		<projectile>
 			<speed>30</speed>
+            <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -115,6 +115,7 @@
           <amount>18</amount>
         </li>
       </secondaryDamage>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 
@@ -130,6 +131,7 @@
           <amount>9</amount>
         </li>
       </secondaryDamage>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -115,6 +115,7 @@
           <amount>24</amount>
         </li>
       </secondaryDamage>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 
@@ -130,6 +131,7 @@
           <amount>12</amount>
         </li>
       </secondaryDamage>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -123,6 +123,7 @@
           <amount>4</amount>
         </li>
       </secondaryDamage>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -123,6 +123,7 @@
           <amount>5</amount>
         </li>
       </secondaryDamage>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -140,6 +140,7 @@
           <amount>18</amount>
         </li>
       </secondaryDamage>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 
@@ -155,6 +156,7 @@
           <amount>9</amount>
         </li>
       </secondaryDamage>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/Rocket/84x246mmR.xml
+++ b/Defs/Ammo/Rocket/84x246mmR.xml
@@ -98,6 +98,7 @@
 		<projectile>
 			<speed>51</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+            <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>	
 

--- a/Defs/Ammo/Rocket/M72LAW.xml
+++ b/Defs/Ammo/Rocket/M72LAW.xml
@@ -17,6 +17,7 @@
 			<armorPenetration>2.1</armorPenetration>
       <speed>40</speed>
       <soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Rocket/RPG7.xml
+++ b/Defs/Ammo/Rocket/RPG7.xml
@@ -125,6 +125,7 @@
 		<projectile>
 			<speed>65</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+            <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>	
 

--- a/Defs/Ammo/Rocket/RPO.xml
+++ b/Defs/Ammo/Rocket/RPO.xml
@@ -18,6 +18,7 @@
 		<projectile>
 			<speed>51</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+            <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>	
 

--- a/Defs/Ammo/Rocket/SPG9.xml
+++ b/Defs/Ammo/Rocket/SPG9.xml
@@ -100,6 +100,7 @@
 		<projectile>
 			<speed>65</speed>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
+           <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>	
 

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -139,6 +139,7 @@
       <flyOverhead>true</flyOverhead>
       <dropsCasings>true</dropsCasings>
       <casingMoteDefname>Mote_BigShell</casingMoteDefname>
+      <allowPenetrateTrough>false</allowPenetrateTrough>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -123,6 +123,7 @@
 	  		<flyOverhead>false</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Mote_BigShell</casingMoteDefname>
+            <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -179,6 +179,7 @@
 			<damageAmountBase>6</damageAmountBase>
 			<armorPenetration>0.151</armorPenetration>
 			<spreadMult>2</spreadMult>
+            <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -148,6 +148,7 @@
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetration>0.141</armorPenetration>
 			<spreadMult>2</spreadMult>
+            <allowPenetrateTrough>false</allowPenetrateTrough>
 		</projectile>
 	</ThingDef>
 	

--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -30,6 +30,9 @@
   <CE_CoverHeight>Cover height</CE_CoverHeight>
   <CE_TargetHeight>Target height</CE_TargetHeight>
   <CE_TargetWidth>Target width</CE_TargetWidth>
+  
+  <!-- Change barrel -->
+  <CE_ChangingBarrelMote>changing barrel</CE_ChangingBarrelMote>
 
   <!-- Reloading -->
   <CE_ReloadingEquipment>equipped</CE_ReloadingEquipment>

--- a/Source/CombatExtended/CombatExtended/Comps/CompProperties_AmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompProperties_AmmoUser.cs
@@ -15,10 +15,20 @@ namespace CombatExtended
         public bool throwMote = true;
         public AmmoSetDef ammoSet = null;
         public bool spawnUnloaded = false;
+        public float changeBarrelTime = 0f;		// How much time in seconds need to change barrel
+        public List<ChangeableBarrel> changeableBarrels = null;		// Changeable barrels
 
         public CompProperties_AmmoUser()
         {
             compClass = typeof(CompAmmoUser);
+        }
+        /// <summary>
+        /// Represents a barrel.
+        /// </summary>
+        public class ChangeableBarrel
+        {
+            public AmmoSetDef ammoSet = null;	// Which ammo set this barrel support
+            public int magazineSize = 0;		// Magazine size of this barrel
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Defs/AmmoCategoryDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoCategoryDef.cs
@@ -11,6 +11,8 @@ namespace CombatExtended
         public bool advanced = false;
         public string labelShort;
 
+        public bool allowPenetrateTrough = true;
+
         public string LabelCapShort => labelShort.CapitalizeFirst();
     }
 }

--- a/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
@@ -12,6 +12,27 @@ namespace CombatExtended
     public class BulletCE : ProjectileCE
     {
         private const float StunChance = 0.1f;
+        private float armorPenetration = -1;
+
+        /// <summary>
+        /// Armor penetration of this bullet. Everytime this bullet hit something, this value will be reduced using ArmorUtilityCE.TryPenetrateArmor() method.
+        /// </summary>
+        /// <value>The armor penetration.</value>
+        private float ArmorPenetration
+        {
+        	get
+        	{
+        		if (armorPenetration < 0)
+        		{
+        			armorPenetration = ((ProjectilePropertiesCE)def.projectile).armorPenetration;
+        		}
+        		return armorPenetration;
+        	}
+        	set
+        	{
+        		armorPenetration = value;
+        	}
+        }
 
         private void LogImpact(Thing hitThing, out BattleLogEntry_RangedImpact logEntry)
         {
@@ -41,7 +62,9 @@ namespace CombatExtended
             {
             	LogImpact(hitThing, out logEntry);
             }
-            
+
+            float relaunchSpeed = -1f;
+
             if (hitThing != null)
             {
                 int damageAmountBase = def.projectile.damageAmountBase;
@@ -61,27 +84,67 @@ namespace CombatExtended
                 BodyPartHeight partHeight = new CollisionVertical(hitThing).GetCollisionBodyHeight(ExactPosition.y);
                 dinfo.SetBodyRegion(partHeight, partDepth);
                 if (damDefCE != null && damDefCE.harmOnlyOutsideLayers) dinfo.SetBodyRegion(BodyPartHeight.Undefined, BodyPartDepth.Outside);
+                // Choose a part before TakeDamage method call, because I need it to help ArmorUtilityCE.GetAfterArmorDamage() to find this bullet.
+                Pawn pawn = hitThing as Pawn;
+                BodyPartRecord hitPart = null;
+                if (pawn != null)
+                {
+                    hitPart = pawn.health.hediffSet.GetRandomNotMissingPart(dinfo.Def, dinfo.Height, dinfo.Depth);
+                    dinfo.SetHitPart(hitPart);
+                }
+                Bullet_ArmorPenetrationTrackerCE.Bullet_ArmorPenetrationRecordCE record = Bullet_ArmorPenetrationTrackerCE.records.Find((r) => r.launcher == launcher && r.bulletDef == def && r.damageDef == def.projectile.damageDef && r.hitPart == hitPart);
+                if (record != null)
+                {
+                    Log.Message("Error: A Pawn has damaged the same part with the same weapon the same damage type at the same time.");
+                }
+                record = new Bullet_ArmorPenetrationTrackerCE.Bullet_ArmorPenetrationRecordCE(launcher, def, def.projectile.damageDef, hitPart, ArmorPenetration);
+                Bullet_ArmorPenetrationTrackerCE.records.Add(record);
 
                 // Apply primary damage
                 hitThing.TakeDamage(dinfo).InsertIntoLog(logEntry);
 
+                // Delete the record
+                Bullet_ArmorPenetrationTrackerCE.records.Remove(record);
+
                 // Apply secondary to non-pawns (pawn secondary damage is handled in the damage worker)
                 var projectilePropsCE = def.projectile as ProjectilePropertiesCE;
-                if(!(hitThing is Pawn) && projectilePropsCE != null && !projectilePropsCE.secondaryDamage.NullOrEmpty())
+                if(projectilePropsCE != null && !projectilePropsCE.secondaryDamage.NullOrEmpty())
                 {
-                    foreach(SecondaryDamage cur in projectilePropsCE.secondaryDamage)
+                    if(!(hitThing is Pawn))
                     {
+                        foreach(SecondaryDamage cur in projectilePropsCE.secondaryDamage)
+                        {
                         if (hitThing.Destroyed) break;
                         var secDinfo = new DamageInfo(
-                            cur.def,
-                            cur.amount,
-                            ExactRotation.eulerAngles.y,
-                            launcher,
-                            null,
-                            def);
+							cur.def,
+							cur.amount,
+							ExactRotation.eulerAngles.y,
+							launcher,
+							null,
+							def);
                         hitThing.TakeDamage(secDinfo).InsertIntoLog(logEntry);
+                        }
                     }
                 }
+
+                if (pawn == null)
+                {
+                    float HPToArmor = hitThing.MaxHitPoints * ArmorUtilityCE.HPToArmorRate;
+                    float useless = -1f;
+                    ArmorUtilityCE.TryPenetrateArmor(def.projectile.damageDef, HPToArmor, ref record.armorPenetration, ref useless);
+                }
+
+                if (!projectilePropsCE.allowPenetrateTrough || record.armorPenetration < ArmorUtilityCE.RequiredAPToPenetrate)
+                {
+                    ExactPosition = ExactPosition;
+                    landed = true;
+                }
+                else
+                {
+                    relaunchSpeed = shotSpeed * (record.armorPenetration / ArmorPenetration);
+                }
+
+                ArmorPenetration = record.armorPenetration;
             }
             else
             {
@@ -92,6 +155,20 @@ namespace CombatExtended
                 	MoteMaker.MakeStaticMote(ExactPosition, map, ThingDefOf.Mote_ShotHit_Dirt, 1f);
             }
             base.Impact(hitThing);
+
+            if (relaunchSpeed > 0f)
+                relaunch(hitThing, relaunchSpeed);
+        }
+
+        /// <summary>
+        /// Save armor Penetration
+        /// </summary>
+        public override void ExposeData()
+        {
+        	base.ExposeData();
+
+        	Scribe_Values.Look<float>(ref armorPenetration, "ap", -1f);
+
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Projectiles/Bullet_ArmorPenetrationTrackerCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/Bullet_ArmorPenetrationTrackerCE.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Verse;
+using System.Collections.Generic;
+namespace CombatExtended
+{
+	public class Bullet_ArmorPenetrationTrackerCE
+	{
+        public static List<Bullet_ArmorPenetrationRecordCE> records = new List<Bullet_ArmorPenetrationRecordCE>();
+
+        public class Bullet_ArmorPenetrationRecordCE
+		{
+			public Thing launcher;
+			public ThingDef bulletDef;
+			public DamageDef damageDef;
+			public BodyPartRecord hitPart;
+			public float armorPenetration;
+
+            /// <summary>
+            /// A bullet-ap pair record. First 4 parms represent a bullet, sense I can't put a bullet reference into a DamageInfo.
+            /// <see cref="T:CombatExtended.Bullet_ArmorPenetrationTrackerCE.Bullet_ArmorPenetrationRecordCE"/> class.
+            /// </summary>
+            /// <param name="launcher">Launcher.</param>
+            /// <param name="bulletDef">Bullet def.</param>
+            /// <param name="damageDef">Damage def.</param>
+            /// <param name="hitPart">Hit part.</param>
+            /// <param name="armorPenetration">Armor penetration.</param>
+            public Bullet_ArmorPenetrationRecordCE(Thing launcher, ThingDef bulletDef, DamageDef damageDef, BodyPartRecord hitPart, float armorPenetration)
+			{
+				this.launcher = launcher;
+                this.bulletDef = bulletDef;
+				this.damageDef = damageDef;
+				this.hitPart = hitPart;
+				this.armorPenetration = armorPenetration;
+			}
+		}
+	}
+}

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -61,6 +61,8 @@ namespace CombatExtended
         protected ThingDef equipmentDef;
         protected Thing launcher;
         public Thing intendedTarget;
+        // Last impacted thing, will be ignored when relaunch sense it has already been hit.
+        protected Thing lastImpactedThing;
         public float minCollisionSqr;
         public bool canTargetSelf;
         public bool castShadow = true;
@@ -362,6 +364,7 @@ namespace CombatExtended
             Scribe_Values.Look<Vector2>(ref origin, "ori", default(Vector2), true);
             Scribe_Values.Look<int>(ref ticksToImpact, "tTI", 0, true);
             Scribe_References.Look<Thing>(ref intendedTarget, "iT");
+            Scribe_References.Look<Thing>(ref lastImpactedThing,"lIT");
             Scribe_References.Look<Thing>(ref launcher, "lcr");
             Scribe_Defs.Look<ThingDef>(ref equipmentDef, "ed");
             Scribe_Values.Look<bool>(ref landed, "lnd", false, false);
@@ -416,6 +419,27 @@ namespace CombatExtended
                 SoundInfo info = SoundInfo.InMap(this, MaintenanceType.PerTick);
                 ambientSustainer = def.projectile.soundAmbient.TrySpawnSustainer(info);
             }
+        }
+
+        /// <summary>
+        /// Relaunch this bullet with new speed and ignoring just hit Thing.
+        /// </summary>
+        /// <returns>The relaunch.</returns>
+        /// <param name="lastImpactedThing">Thing that this bullet just hit, will be ignored when relaunch to avoid multiple hits</param>
+        /// <param name="newSpeed">New speed.</param>
+        protected void relaunch(Thing lastImpactedThing, float newSpeed)
+        {
+        	lastHeightTick = -1;
+        	float currentHeight = Height;
+
+        	shotHeight = currentHeight;
+        	shotSpeed = newSpeed;
+        	this.lastImpactedThing = lastImpactedThing;
+        	intTicksToImpact = -1;
+        	startingTicksToImpactInt = -1;
+        	destinationInt = new Vector3(0f, 0f, -1f);
+        	intendedTarget = null;
+        	ticksToImpact = IntTicksToImpact;
         }
         #endregion
         
@@ -511,14 +535,25 @@ namespace CombatExtended
             	}
             	roofChecked = true;
             }
-            
+
+            float suppressionModifier = 1f;
+
             foreach (Thing thing in mainThingList.Distinct().OrderBy(x => (x.DrawPos - LastPos).sqrMagnitude))
             {
                 if (thing == launcher && !canTargetSelf) continue;
 				
                 // Check for collision
                 if (TryCollideWith(thing))
-                	return true;
+                {
+                    if (landed)
+                    {
+                        return true;
+                    }
+                    else if (thing is Building)
+                    {
+                        suppressionModifier *= 1.5f;
+                    }
+                }
 				
                 // Apply suppression. The height here is NOT that of the bullet in CELL,
                 // it is the height at the END OF THE PATH. This is because SuppressionRadius
@@ -528,7 +563,7 @@ namespace CombatExtended
 	                Pawn pawn = thing as Pawn;
 	                if (pawn != null)
 	                {
-	                    ApplySuppression(pawn);
+	                    ApplySuppression(pawn, suppressionModifier);
 	                }
                 }
             }
@@ -574,6 +609,11 @@ namespace CombatExtended
         /// <returns>True if impact occured, false otherwise</returns>
         private bool TryCollideWith(Thing thing)
         {
+            // Ignore last impacted thing to avoid multiple hit to the same thing due to relaunch.
+            if (thing == lastImpactedThing)
+            {
+                return false;
+            }
             if (thing == launcher && !canTargetSelf)
             {
                 return false;
@@ -604,9 +644,6 @@ namespace CombatExtended
             var point = ShotLine.GetPoint(dist);
             if (!point.InBounds(this.Map))
             	Log.Error("TryCollideWith out of bounds point from ShotLine: obj " + thing.ThingID + ", proj " + this.ThingID + ", dist " + dist + ", point " + point);
-            	
-            ExactPosition = point;
-        	landed = true;
         	
             if (DebugViewSettings.drawInterceptChecks) MoteMaker.ThrowText(thing.Position.ToVector3Shifted(), thing.Map, "x", Color.red);
             
@@ -615,7 +652,7 @@ namespace CombatExtended
         }
         #endregion
 
-        private void ApplySuppression(Pawn pawn)
+        private void ApplySuppression(Pawn pawn, float modifier = 1f)
         {
             ShieldBelt shield = null;
             if (pawn.RaceProps.Humanlike)
@@ -642,7 +679,7 @@ namespace CombatExtended
                 suppressionAmount = def.projectile.damageAmountBase;
                 var propsCE = def.projectile as ProjectilePropertiesCE;
                 float penetrationAmount = propsCE == null ? 0f : propsCE.armorPenetration;
-                suppressionAmount *= 1 - Mathf.Clamp(compSuppressable.ParentArmor - penetrationAmount, 0, 1);
+                suppressionAmount *= 1 - Mathf.Clamp(compSuppressable.ParentArmor - penetrationAmount, 0, 1) * modifier;
                 compSuppressable.AddSuppression(suppressionAmount, OriginIV3);
             }
         }
@@ -788,7 +825,7 @@ namespace CombatExtended
 				{
 					FilthMaker.MakeFilth(Position, Map, thingDef, 1);
 				}
-				else
+                else if (landed)
 				{
 					Thing reusableAmmo = ThingMaker.MakeThing(thingDef, null);
 					reusableAmmo.stackCount = 1;
@@ -810,7 +847,7 @@ namespace CombatExtended
 	            }
             }
 
-            Destroy();
+            if (landed || comp!=null) Destroy();
         }
 		#endregion
 

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectilePropertiesCE.cs
@@ -18,6 +18,7 @@ namespace CombatExtended
         public bool dropsCasings = false;
         public string casingMoteDefname = "Mote_EmptyCasing";
         public float gravityFactor = 1;
+        public bool allowPenetrateTrough = true;
 
         public float Gravity => CE_Utility.gravityConst * gravityFactor;
     }

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Caliber.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Caliber.cs
@@ -22,12 +22,17 @@ namespace CombatExtended
             var ammoProps = (req.Def as ThingDef)?.GetCompProperties<CompProperties_AmmoUser>();
             if (ammoProps != null)
             {
-                // Append various ammo stats
-                stringBuilder.AppendLine(ammoProps.ammoSet.LabelCap + "\n");
-                foreach (var cur in ammoProps.ammoSet.ammoTypes)
+                if (ammoProps.changeableBarrels != null)
                 {
-                    string label = string.IsNullOrEmpty(cur.ammo.ammoClass.LabelCapShort) ? cur.ammo.ammoClass.LabelCap : cur.ammo.ammoClass.LabelCapShort;
-                    stringBuilder.AppendLine(label + ":\n" + cur.projectile.GetProjectileReadout());
+                    foreach(CompProperties_AmmoUser.ChangeableBarrel barrel in ammoProps.changeableBarrels)
+                    {
+                        writeSingleCaliber(stringBuilder,barrel.ammoSet,barrel.magazineSize);
+                        stringBuilder.AppendLine();
+                    }
+                }
+                else
+                {
+                    writeSingleCaliber(stringBuilder,ammoProps.ammoSet,ammoProps.magazineSize);
                 }
             }
             return stringBuilder.ToString().TrimEndNewlines();
@@ -35,7 +40,34 @@ namespace CombatExtended
 
         public override string GetStatDrawEntryLabel(StatDef stat, float value, ToStringNumberSense numberSense, StatRequest optionalReq)
         {
-            return (optionalReq.Def as ThingDef)?.GetCompProperties<CompProperties_AmmoUser>().ammoSet.LabelCap;
+            CompProperties_AmmoUser ammoProps = (optionalReq.Def as ThingDef)?.GetCompProperties<CompProperties_AmmoUser>();
+            StringBuilder stringBuilder = new StringBuilder();
+            if (ammoProps!=null && ammoProps.changeableBarrels != null)
+            {
+                ammoProps.changeableBarrels.Aggregate(false,(x, y) => 
+                {
+                    if (x == true) stringBuilder.Append(',');
+                    stringBuilder.Append(y.ammoSet.LabelCap);
+                    return true;
+                });
+            }
+            else
+            {
+                stringBuilder.Append(ammoProps?.ammoSet.LabelCap);
+            }
+            return stringBuilder.ToString();
+        }
+
+        private void writeSingleCaliber(StringBuilder stringBuilder, AmmoSetDef ammoSet, int magazineSize)
+        {
+            // Append various ammo stats
+                stringBuilder.AppendLine(ammoSet.LabelCap);
+                stringBuilder.AppendLine(string.Format("CE_MagazineSize".Translate()+": "+magazineSize) + "\n");
+                foreach (var cur in ammoSet.ammoTypes)
+                {
+                    string label = string.IsNullOrEmpty(cur.ammo.ammoClass.LabelCapShort) ? cur.ammo.ammoClass.LabelCap : cur.ammo.ammoClass.LabelCapShort;
+                    stringBuilder.AppendLine(label + ":\n" + cur.projectile.GetProjectileReadout());
+                }
         }
     }
 }


### PR DESCRIPTION
Bullet Penetration - implemented #476

Allow bullet to penetrate body, walls, etc.
When penetrating body, generated armor = ( MaxHP of all hit organs ) * 0.006.
When penetrating other things, generated armor = MaxHP * 0.006
If remaining AP > 0.15, then penetrate. 
When penetrated any thing other than a pawn, generate 50% extra suppression.
After penetration, bullet will fly in the same rotation,  current height, reduced speed.

------------------------------------------------------------------------------------
partially implemented #483. Implemented changeable barrel. Now we can have fn scar and p320.

Example:

    <changeBarrelTime>12</changeBarrelTime>
    <changeableBarrels>
        <li>
           <ammoSet>AmmoSet_545x39mmSoviet</ammoSet>
           <magazineSize>60</magazineSize>
       </li>
       <li>
           <ammoSet>AmmoSet_762x39mmSoviet</ammoSet>
           <magazineSize>40</magazineSize>
       </li>
    </changeableBarrels>

changeBarrelTime: How long time in seconds need to change barrel for this gun.
changeableBarrels: A list of changeable barrel.
ammoSet: Ammo set of this barrel
magazineSize: Magazine size of this barrel

Those markup must under the \<li Class="CombatExtended.CompProperties_AmmoUser"> element. It's actually "changeBarrelTime" property and "changeableBarrels" property of CombatExtended.CompProperties_AmmoUser class.