### PR TITLE
Fix for forum issue & Settings moved

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -245,7 +245,7 @@ namespace CombatExtended
 
             if (dinfo.Weapon != null)
             {
-                // Case 1: projectile attack
+                // Case 1: projectile attack (Weapon.projectile indicates that Weapon IS a projectile)
                 ProjectilePropertiesCE projectileProps = dinfo.Weapon.projectile as ProjectilePropertiesCE;
                 if (projectileProps != null)
                 {
@@ -267,16 +267,19 @@ namespace CombatExtended
                             return 0;
                         }
                         var penetrationMult = equipment.GetStatValue(CE_StatDefOf.MeleePenetrationFactor);
-                        var tool = equipment.def.tools.OfType<ToolCE>().GetUsedTool(dinfo);
-                        
-                        return tool.armorPenetration * penetrationMult;
+                        var tool = equipment.def.tools?.OfType<ToolCE>().GetUsedTool(dinfo);
+
+                        if (tool != null)
+                            return tool.armorPenetration * penetrationMult;
                     }
                     
                     // Case 2.2: .. of a ranged weapon
                     if (dinfo.Weapon.IsRangedWeapon)
                     {
-                    	var tool = dinfo.Weapon.tools.OfType<ToolCE>().GetUsedTool(dinfo);
-                    	return tool.armorPenetration;
+                    	var tool = dinfo.Weapon.tools?.OfType<ToolCE>().GetUsedTool(dinfo);
+
+                        if (tool != null)
+                            return tool.armorPenetration;
                     }
                     
                     // Case 2.3: .. of the pawn
@@ -289,7 +292,7 @@ namespace CombatExtended
                         HediffCompProperties_VerbGiver compProps = dinfo.WeaponLinkedHediff?.CompPropsFor(typeof(HediffComp_VerbGiver)) as HediffCompProperties_VerbGiver;
                         if (compProps != null)
                         {
-                        	var tool = compProps.tools.OfType<ToolCE>().GetUsedTool(dinfo);
+                        	var tool = compProps.tools?.OfType<ToolCE>().GetUsedTool(dinfo);
                         	
                         	if (tool != null)
                         		return tool.armorPenetration;

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -775,7 +775,6 @@ namespace CombatExtended
 			
 			//Spawn things if not an explosive but preExplosionSpawnThingDef != null
             if (Controller.settings.EnableAmmoSystem
-	        	&& Controller.settings.ReuseNeolithicProjectiles
 	    		&& comp == null
 		    	&& Position.IsValid
 				&& def.projectile.preExplosionSpawnChance > 0
@@ -788,7 +787,7 @@ namespace CombatExtended
 				{
 					FilthMaker.MakeFilth(Position, Map, thingDef, 1);
 				}
-				else
+				else if (Controller.settings.ReuseNeolithicProjectiles)
 				{
 					Thing reusableAmmo = ThingMaker.MakeThing(thingDef, null);
 					reusableAmmo.stackCount = 1;


### PR DESCRIPTION
- Fix for
https://ludeon.com/forums/index.php?topic=28843.msg407580#msg407580 in
ArmorUtilityCE, by checking for null
equipment.def.tools?.OfType<ToolCE>()

- ReuseNeolithicProjectiles = false now doesn't prevent filth to be
generated on impact if the projectile kind so desires