### PR TITLE
XML fixes

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -74,7 +74,7 @@
       <MarketValue>1.94</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-    <canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/30x64mmFuelCell.xml
@@ -75,7 +75,7 @@
       <MarketValue>0.61</MarketValue>
     </statBases>
     <ammoClass>FoamFuel</ammoClass>
-    <canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Advanced/6x18mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x18mmCharged.xml
@@ -74,7 +74,7 @@
       <MarketValue>0.89</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-    <canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -74,7 +74,7 @@
       <MarketValue>0.97</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-    <canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Advanced/8x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/8x35mmCharged.xml
@@ -74,7 +74,7 @@
       <MarketValue>1.38</MarketValue>
     </statBases>
     <ammoClass>Ionized</ammoClass>
-    <canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Medieval/CrossbowBolts.xml
+++ b/Defs/Ammo/Medieval/CrossbowBolts.xml
@@ -80,7 +80,7 @@
       <MarketValue>3.63</MarketValue>
     </statBases>
 		<ammoClass>PlasteelCrossbowBolt</ammoClass>
-		<canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -80,7 +80,7 @@
       <MarketValue>3.32</MarketValue>
     </statBases>
 		<ammoClass>PlasteelArrow</ammoClass>
-		<canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Neolithic/GreatArrows.xml
+++ b/Defs/Ammo/Neolithic/GreatArrows.xml
@@ -80,7 +80,7 @@
       <MarketValue>3.46</MarketValue>
     </statBases>
 		<ammoClass>PlasteelArrow</ammoClass>
-		<canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Neolithic/SlingBullet.xml
+++ b/Defs/Ammo/Neolithic/SlingBullet.xml
@@ -79,7 +79,7 @@
       <MarketValue>3.16</MarketValue>
     </statBases>
 		<ammoClass>PlasteelSlingBullet</ammoClass>
-		<canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Neolithic/StreamlinedArrows.xml
+++ b/Defs/Ammo/Neolithic/StreamlinedArrows.xml
@@ -80,7 +80,7 @@
       <MarketValue>3.38</MarketValue>
     </statBases>
 		<ammoClass>PlasteelArrow</ammoClass>
-		<canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -165,9 +165,9 @@
       <Mass>6.5</Mass>
       <Bulk>6</Bulk>
     </statBases>
-    <itemGeneratorTags>
-      <li>SpecialReward</li>
-    </itemGeneratorTags>
+    <thingSetMakerTags>
+      <li>RewardSpecial</li>
+    </thingSetMakerTags>
     <tradeability>Sellable</tradeability>
     <ammoClass>Antigrain</ammoClass>
     <comps>

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -86,7 +86,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="12GaugeBase">
     <defName>Ammo_12Gauge_Beanbag</defName>
     <label>12 gauge shell (Bean)</label>
-	<canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
     <graphicData>
       <texPath>Things/Ammo/Shotgun/Beanbag</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -70,7 +70,7 @@
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="23x75mmRBase">
     <defName>Ammo_23x75mmR_Beanbag</defName>
     <label>23x75mmR shell (Bean)</label>
-	<canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
     <graphicData>
       <texPath>Things/Ammo/Shotgun/Beanbag</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>

--- a/Defs/ThingDefs_Misc/Weapons_Spotting.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Spotting.xml
@@ -24,7 +24,7 @@
       <texPath>Things/Weapons/BinocularsRadio</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
-    <canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
     <soundInteract>Interact_Rifle</soundInteract>
     <statBases>
       <WorkToMake>10500</WorkToMake>

--- a/Defs/ThingDefs_Misc/Weapons_Turrets.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Turrets.xml
@@ -10,7 +10,7 @@
     <tradeability>None</tradeability>
     <destroyOnDrop>True</destroyOnDrop>
     <menuHidden>True</menuHidden>
-    <canBeSpawningInventory>false</canBeSpawningInventory>
+	<generateAllowChance>0</generateAllowChance>
     <smeltable>false</smeltable>
   </ThingDef>
 

--- a/Patches/Core/Bodies/Bodies_Animal_Bird/Bodies_Animal_Bird.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Bird/Bodies_Animal_Bird.xml
@@ -79,7 +79,7 @@
 </Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "LeftLeg"]/parts/li[def = "Foot"]/coverage</xpath>
+  	<xpath>/Defs/BodyDef[defName = "Bird"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Foot"]/coverage</xpath>	<!-- in 1.0: patch both left and right leg (no distinction made anymore) -->
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/Monkey.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/Monkey.xml
@@ -13,9 +13,9 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Rib"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "Monkey"]/corePart/parts/li[def = "Ribcage"]/coverage</xpath>	<!-- b18: 12 ribs with 0.004 coverage (CE: 0.001 coverage) each. 1.0: ribcage with 0.045 coverage (CE: 0.012?) -->
   	<value>
-    	<coverage>0.001</coverage>
+    	<coverage>0.012</coverage>
   	</value>
 	</Operation>
 

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithClawsTailAndJowl.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithClawsTailAndJowl.xml
@@ -105,59 +105,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "FrontLeftLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "FrontRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "RearLeftLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "RearRightLeg"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -210,28 +162,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -268,28 +199,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "LeftLung"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.06</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "RightLung"]/coverage</xpath>
-  	<value>
-    	<coverage>0.06</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "LeftKidney"]/coverage</xpath>
-  	<value>
-    	<coverage>0.015</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "RightKidney"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.015</coverage>
   	</value>
@@ -331,28 +248,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEye"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEye"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEar"]/coverage</xpath>
-  	<value>
-    	<coverage>0.05</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEar"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
@@ -373,28 +276,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "FrontLeftLeg"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "FrontRightLeg"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "RearLeftLeg"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "RearRightLeg"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithClawsTailAndJowl"]/corePart/parts/li[def = "Leg"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHooves.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHooves.xml
@@ -89,11 +89,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontLeftLeg"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -105,107 +105,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearLeftLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -251,56 +155,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -323,28 +185,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "LeftLung"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RightLung"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "LeftKidney"]/coverage</xpath>
-  	<value>
-    	<coverage>0.025</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RightKidney"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
@@ -379,28 +227,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEye"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEye"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEar"]/coverage</xpath>
-  	<value>
-    	<coverage>0.12</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEar"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
@@ -414,28 +248,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHooves"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHorn.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHorn.xml
@@ -105,11 +105,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontLeftLeg"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -121,107 +121,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearLeftLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -274,56 +178,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -346,33 +208,19 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "LeftLung"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RightLung"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "LeftKidney"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
 	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RightKidney"]/coverage</xpath>
-  	<value>
-    	<coverage>0.025</coverage>
-  	</value>
-	</Operation>
-
+	
 	<Operation Class="PatchOperationReplace">
   	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Liver"]/coverage</xpath>
   	<value>
@@ -409,28 +257,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEye"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEye"]/coverage</xpath>
-  	<value>
-    	<coverage>0.05</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEar"]/coverage</xpath>
-  	<value>
-    	<coverage>0.05</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEar"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
@@ -451,28 +285,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHorn"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHump.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndHump.xml
@@ -105,11 +105,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontLeftLeg"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -121,107 +121,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearLeftLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -274,56 +178,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -346,28 +208,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "LeftLung"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RightLung"]/coverage</xpath>
-  	<value>
-    	<coverage>0.07</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "LeftKidney"]/coverage</xpath>
-  	<value>
-    	<coverage>0.02</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RightKidney"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.02</coverage>
   	</value>
@@ -402,56 +250,21 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEye"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEye"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEar"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEar"]/coverage</xpath>
-  	<value>
-    	<coverage>0.12</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndHump"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndTusks.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndTusks.xml
@@ -89,11 +89,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontLeftLeg"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -105,107 +105,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearLeftLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -251,56 +155,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -323,28 +185,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "LeftLung"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RightLung"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "LeftKidney"]/coverage</xpath>
-  	<value>
-    	<coverage>0.025</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RightKidney"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
@@ -379,28 +227,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEye"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEye"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEar"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEar"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>
@@ -414,46 +248,18 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/parts/li[def = "LeftTusk"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/parts/li[def = "Tusk"]/coverage</xpath>
   	<value>
     	<coverage>0.25</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/parts/li[def = "RightTusk"]/coverage</xpath>
-  	<value>
-    	<coverage>0.25</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>
 	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesAndTusks"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
+	
 </Patch>
 

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesTusksAndTrunk.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesTusksAndTrunk.xml
@@ -89,11 +89,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontLeftLeg"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -105,107 +105,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearLeftLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -251,56 +155,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -323,28 +185,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "LeftLung"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RightLung"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "LeftKidney"]/coverage</xpath>
-  	<value>
-    	<coverage>0.025</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RightKidney"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
@@ -386,28 +234,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEye"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.05</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEye"]/coverage</xpath>
-  	<value>
-    	<coverage>0.05</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEar"]/coverage</xpath>
-  	<value>
-    	<coverage>0.15</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEar"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.15</coverage>
   	</value>
@@ -428,42 +262,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/parts/li[def = "LeftTusk"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/parts/li[def = "Tusk"]/coverage</xpath>
   	<value>
     	<coverage>0.25</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/parts/li[def = "RightTusk"]/coverage</xpath>
-  	<value>
-    	<coverage>0.25</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftHoof"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightHoof"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithHoovesTusksAndTrunk"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Hoof"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPaws.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPaws.xml
@@ -89,11 +89,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontLeftLeg"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -105,107 +105,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftPaw"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftPaw"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightPaw"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightPaw"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearLeftLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftPaw"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftPaw"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightPaw"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightPaw"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -251,56 +155,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftPaw"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightPaw"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftPaw"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightPaw"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -323,28 +185,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "LeftLung"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RightLung"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "LeftKidney"]/coverage</xpath>
-  	<value>
-    	<coverage>0.025</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RightKidney"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
@@ -379,28 +227,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEye"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEye"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEar"]/coverage</xpath>
-  	<value>
-    	<coverage>0.12</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEar"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
@@ -414,28 +248,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftPaw"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightPaw"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftPaw"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightPaw"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPaws"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPawsAndTail.xml
+++ b/Patches/Core/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithPawsAndTail.xml
@@ -89,11 +89,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontLeftLeg"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -105,107 +105,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftPaw"]/groups</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftPaw"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightPaw"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightPaw"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearLeftLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftPaw"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftPaw"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearRightLeg"]</xpath>
-      	<value>
-        	<groups />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightPaw"]/groups</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightPaw"]</xpath>
+      	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]</xpath>
       	<value>
         	<groups />
       	</value>
@@ -251,56 +155,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontLeftLeg"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftPaw"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightPaw"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearLeftLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftPaw"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearRightLeg"]/groups</xpath>
-  	<value>
-      <li>CoveredByNaturalArmor</li>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightPaw"]/groups</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/groups</xpath>
   	<value>
       <li>CoveredByNaturalArmor</li>
   	</value>
@@ -330,28 +192,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "LeftLung"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Lung"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RightLung"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "LeftKidney"]/coverage</xpath>
-  	<value>
-    	<coverage>0.025</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RightKidney"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Kidney"]/coverage</xpath>
   	<value>
     	<coverage>0.025</coverage>
   	</value>
@@ -386,28 +234,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEye"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
   	<value>
     	<coverage>0.08</coverage>
   	</value>
 	</Operation>
-
+	
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEye"]/coverage</xpath>
-  	<value>
-    	<coverage>0.08</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "LeftEar"]/coverage</xpath>
-  	<value>
-    	<coverage>0.12</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "RightEar"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
   	<value>
     	<coverage>0.12</coverage>
   	</value>
@@ -421,28 +255,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontLeftLeg"]/parts/li[def = "FrontLeftPaw"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "FrontRightLeg"]/parts/li[def = "FrontRightPaw"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearLeftLeg"]/parts/li[def = "RearLeftPaw"]/coverage</xpath>
-  	<value>
-    	<coverage>0.1</coverage>
-  	</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "RearRightLeg"]/parts/li[def = "RearRightPaw"]/coverage</xpath>
+  	<xpath>*/BodyDef[defName = "QuadrupedAnimalWithPawsAndTail"]/corePart/parts/li[def = "Leg"]/parts/li[def = "Paw"]/coverage</xpath>
   	<value>
     	<coverage>0.1</coverage>
   	</value>

--- a/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
+++ b/Patches/Core/Bodies/Bodies_Humanlike/Human.xml
@@ -15,9 +15,9 @@
   <!-- ========== Modify coverage ========== -->
 
 	<Operation Class="PatchOperationReplace">
-  	<xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Rib"]/coverage</xpath>
+  	<xpath>/Defs/BodyDef[defName = "Human"]/corePart/parts/li[def = "Ribcage"]/coverage</xpath>
   	<value>
-    	<coverage>0.001</coverage>
+    	<coverage>0.012</coverage>
   	</value>
 	</Operation>
 

--- a/Patches/Core/Bodies/BodyParts_General.xml
+++ b/Patches/Core/Bodies/BodyParts_General.xml
@@ -9,13 +9,6 @@
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>*/BodyPartDef[defName="Rib"]/hitPoints</xpath>
-    <value>
-      <hitPoints>13</hitPoints>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationReplace">
     <xpath>*/BodyPartDef[defName="Leg"]/hitPoints</xpath>
     <value>
       <hitPoints>40</hitPoints>

--- a/Patches/Core/RecipeDefs/Recipes_Production.xml
+++ b/Patches/Core/RecipeDefs/Recipes_Production.xml
@@ -4,10 +4,10 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>*/RecipeDef[defName="SmeltWeapon"]/fixedIngredientFilter</xpath>
 		<value>
-			<exceptedCategories>
+			<disallowedCategories>
 			  <li>Ammo</li>
 			  <li>WeaponsTurrets</li>
-			</exceptedCategories>
+			</disallowedCategories>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -17,17 +17,17 @@
 		</value>
 	</Operation>
 
-	<!-- ========== Improvised turret ========== -->
+	<!-- ========== Mini-turret ========== -->
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="TurretGun"]/thingClass</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/thingClass</xpath>
 		<value>
 			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="TurretGun"]/statBases</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.25</AimingAccuracy>
 			<ShootingAccuracy>0.5</ShootingAccuracy>
@@ -35,39 +35,32 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="TurretGun"]/statBases/Mass</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/statBases/Mass</xpath>
 		<value>
 			<Mass>25</Mass>
 		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="TurretGun"]/label</xpath>
-		<value>
-			<label>auto-turret</label>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationRemove">
-		<xpath>*/ThingDef[defName="TurretGun"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="TurretGun"]/fillPercent</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/fillPercent</xpath>
 		<value>
 			<fillPercent>0.85</fillPercent>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="TurretGun"]/specialDisplayRadius</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/specialDisplayRadius</xpath>
 		<value>
 			<specialDisplayRadius>27</specialDisplayRadius>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="TurretGun"]/building/turretBurstCooldownTime</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/building/turretBurstCooldownTime</xpath>
 		<value>
 			<turretBurstCooldownTime>1.1</turretBurstCooldownTime>
 		</value>
@@ -79,11 +72,11 @@
   	<success>Always</success>
   	<operations>
     	<li Class="PatchOperationTest">
-      	<xpath>*/ThingDef[defName="TurretGun"]/tradeTags</xpath>
+      	<xpath>*/ThingDef[defName="Turret_MiniTurret"]/tradeTags</xpath>
       	<success>Invert</success>
     	</li>
     	<li Class="PatchOperationAdd">
-      	<xpath>*/ThingDef[defName="TurretGun"]</xpath>
+      	<xpath>*/ThingDef[defName="Turret_MiniTurret"]</xpath>
       	<value>
         	<tradeTags />
       	</value>
@@ -92,7 +85,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="TurretGun"]/tradeTags</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/tradeTags</xpath>
 		<value>
 			<li>CE_Turret</li>
 		</value>
@@ -102,28 +95,132 @@
 
 <!--
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="TurretGun"]/costList/Steel</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/costList/Steel</xpath>
 		<value>
 			<Steel>175</Steel>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="TurretGun"]/costList/ComponentIndustrial</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/costList/ComponentIndustrial</xpath>
 		<value>
 			<ComponentIndustrial>8</ComponentIndustrial>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>*/ThingDef[defName="TurretGun"]/stuffCategories</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/stuffCategories</xpath>
 	</Operation>
 
 	<Operation Class="PatchOperationRemove">
-		<xpath>*/ThingDef[defName="TurretGun"]/costStuffCount</xpath>
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/costStuffCount</xpath>
 	</Operation>
 -->
 
+	<!-- ========== Sniper turret ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>*/ThingDef[defName="Turret_Sniper"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>*/ThingDef[defName="Turret_Sniper"]/statBases/Mass</xpath>
+		<value>
+			<Mass>25</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>*/ThingDef[defName="Turret_Sniper"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>*/ThingDef[defName="Turret_Sniper"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.85</fillPercent>
+		</value>
+	</Operation>
+
+	<!-- Add trade tags -->
+
+	<Operation Class="PatchOperationSequence">
+  	<success>Always</success>
+  	<operations>
+    	<li Class="PatchOperationTest">
+      	<xpath>*/ThingDef[defName="Turret_Sniper"]/tradeTags</xpath>
+      	<success>Invert</success>
+    	</li>
+    	<li Class="PatchOperationAdd">
+      	<xpath>*/ThingDef[defName="Turret_Sniper"]</xpath>
+      	<value>
+        	<tradeTags />
+      	</value>
+    	</li>
+  	</operations>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>*/ThingDef[defName="Turret_Sniper"]/tradeTags</xpath>
+		<value>
+			<li>CE_Turret</li>
+		</value>
+	</Operation>
+
+	<!-- ========== Autocannon turret ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>*/ThingDef[defName="Turret_Autocannon"]/thingClass</xpath>
+		<value>
+			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>*/ThingDef[defName="Turret_Autocannon"]/statBases/Mass</xpath>
+		<value>
+			<Mass>25</Mass>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationRemove">
+		<xpath>*/ThingDef[defName="Turret_Autocannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>*/ThingDef[defName="Turret_Autocannon"]/fillPercent</xpath>
+		<value>
+			<fillPercent>0.85</fillPercent>
+		</value>
+	</Operation>
+
+	<!-- Add trade tags -->
+
+	<Operation Class="PatchOperationSequence">
+  	<success>Always</success>
+  	<operations>
+    	<li Class="PatchOperationTest">
+      	<xpath>*/ThingDef[defName="Turret_Autocannon"]/tradeTags</xpath>
+      	<success>Invert</success>
+    	</li>
+    	<li Class="PatchOperationAdd">
+      	<xpath>*/ThingDef[defName="Turret_Autocannon"]</xpath>
+      	<value>
+        	<tradeTags />
+      	</value>
+    	</li>
+  	</operations>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>*/ThingDef[defName="Turret_Autocannon"]/tradeTags</xpath>
+		<value>
+			<li>CE_Turret</li>
+		</value>
+	</Operation>
+	
 	<!-- ========== Mortar Base ========== -->
 
 	<!-- Patch weapon -->

--- a/Patches/Core/ThingDefs_Items/Items.xml
+++ b/Patches/Core/ThingDefs_Items/Items.xml
@@ -19,7 +19,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>edge</id>
 					<label>edge</label>
 					<capacities>
 						<li>Cut</li>
@@ -30,7 +29,6 @@
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>point</id>
 					<label>point</label>
 					<capacities>
 						<li>Stab</li>
@@ -79,7 +77,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>edge</id>
 					<label>edge</label>
 					<capacities>
 						<li>Cut</li>
@@ -90,7 +87,6 @@
 					<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>point</id>
 					<label>point</label>
 					<capacities>
 						<li>Stab</li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-  <!-- ========== Remove elite gun tag from inappropriate weapons ========== -->
-
-  <Operation Class="PatchOperationRemove">
-    <xpath>*/ThingDef[defName="Gun_LMG" or "Gun_AssaultRifle"]/weaponTags/li[.="EliteGun"]</xpath>
-  </Operation>
-
   <!-- ========== Revolver ========== -->
 
   <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -66,7 +66,6 @@
           <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -77,7 +76,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -150,7 +148,6 @@
           <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -161,7 +158,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -232,7 +228,6 @@
           <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -243,7 +238,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -314,7 +308,6 @@
           <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -325,7 +318,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -397,7 +389,6 @@
           <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -408,7 +399,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -485,7 +475,6 @@
           <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -496,7 +485,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -568,7 +556,6 @@
           <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -579,7 +566,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -656,7 +642,6 @@
           <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -667,7 +652,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -744,7 +728,6 @@
           <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -755,7 +738,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -835,7 +817,6 @@
           <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -846,7 +827,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -928,7 +908,6 @@
           <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -939,7 +918,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>
@@ -1017,7 +995,6 @@
           <linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelblunt</id>
           <label>barrel</label>
           <capacities>
             <li>Blunt</li>
@@ -1028,7 +1005,6 @@
           <linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>barrelpoke</id>
           <label>muzzle</label>
           <capacities>
             <li>Poke</li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Melee.xml
@@ -423,7 +423,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>shaftblunt</id>
 					<label>shaft</label>
 					<capacities>
 						<li>Blunt</li>
@@ -434,7 +433,6 @@
 					<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>shaftpoke</id>
 					<label>point</label>
 					<capacities>
 						<li>Poke</li>
@@ -502,7 +500,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>shaftblunt</id>
 					<label>shaft</label>
 					<capacities>
 						<li>Blunt</li>
@@ -513,7 +510,6 @@
 					<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>shaftpoke</id>
 					<label>point</label>
 					<capacities>
 						<li>Poke</li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Melee.xml
@@ -16,8 +16,8 @@
 
 	<!-- ========== Shiv ========== -->
 
-	<!-- Patch stats -->
-
+	<!-- 1.0: Shiv removed from game
+	
 	<Operation Class="PatchOperationReplace">
 		<xpath>*/ThingDef[defName="MeleeWeapon_Shiv"]/tools</xpath>
 		<value>
@@ -64,8 +64,6 @@
 		</value>
 	</Operation>
 
-	<!-- Add tags -->
-
 	<Operation Class="PatchOperationSequence">
   	<success>Always</success>
   	<operations>
@@ -88,7 +86,7 @@
       <li>CE_Sidearm_Melee</li>
       <li>CE_OneHandedWeapon</li>
 		</value>
-	</Operation>
+	</Operation> -->
 
 	<!-- ========== Knife ========== -->
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -37,7 +37,6 @@
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">
-          <id>limb</id>
 		  <label>limb</label>
           <capacities>
             <li>Blunt</li>
@@ -48,7 +47,6 @@
 			<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>nock</id>
 		  <label>nock</label>
           <capacities>
             <li>Poke</li>
@@ -99,7 +97,6 @@
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">
-          <id>limb</id>
 		  <label>limb</label>
           <capacities>
             <li>Blunt</li>
@@ -110,7 +107,6 @@
 			<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>nock</id>
 		  <label>nock</label>
           <capacities>
             <li>Poke</li>
@@ -161,7 +157,6 @@
     <value>
       <tools>
         <li Class="CombatExtended.ToolCE">
-          <id>limb</id>
 		  <label>limb</label>
           <capacities>
             <li>Blunt</li>
@@ -172,7 +167,6 @@
 			<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
         </li>
         <li Class="CombatExtended.ToolCE">
-          <id>nock</id>
 		  <label>nock</label>
           <capacities>
             <li>Poke</li>

--- a/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -149,7 +149,7 @@
     <weaponTags>
       <li>CE_Bow</li>
     </weaponTags>
-    <researchPrerequisite>Greatbows</researchPrerequisite>
+    <researchPrerequisite>Greatbow</researchPrerequisite>
   </Operation>
 
   <Operation Class="PatchOperationReplace">

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Arid.xml
@@ -65,7 +65,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofblunt</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -76,7 +75,6 @@
 					<armorPenetration>0.095</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofpoke</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -87,7 +85,6 @@
 					<armorPenetration>0.07</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofblunt</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -98,7 +95,6 @@
 					<armorPenetration>0.095</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofpoke</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -255,7 +251,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>hornStab</id>
 					<label>horn</label>
 					<capacities>
 						<li>Stab</li>
@@ -266,7 +261,6 @@
 					<armorPenetration>0.341</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>hornBlunt</id>
 					<label>horn</label>
 					<capacities>
 						<li>Blunt</li>
@@ -353,7 +347,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofblunt</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -364,7 +357,6 @@
 					<armorPenetration>0.14</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofpoke</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -375,7 +367,6 @@
 					<armorPenetration>0.101</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofblunt</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -386,7 +377,6 @@
 					<armorPenetration>0.14</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofpoke</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Poke</li>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Bears.xml
@@ -51,7 +51,7 @@
 	<!-- ========== Grizzly Bear ========== -->
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="GrizzlyBear"]</xpath>
+		<xpath>*/ThingDef[defName="Bear_Grizzly"]</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -125,7 +125,7 @@
 	<!-- ========== Polar Bear ========== -->
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="PolarBear"]/statBases</xpath>
+		<xpath>*/ThingDef[defName="Bear_Polar"]/statBases</xpath>
 		<value>
 			<MoveSpeed>4.0</MoveSpeed>
 			<MeleeDodgeChance>0.09</MeleeDodgeChance>
@@ -135,7 +135,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="PolarBear"]</xpath>
+		<xpath>*/ThingDef[defName="Bear_Polar"]</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -207,14 +207,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="PolarBear"]/race</xpath>
+		<xpath>*/ThingDef[defName="Bear_Polar"]/race</xpath>
 		<value>
 			<baseBodySize>1.55</baseBodySize>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="PolarBear"]/race</xpath>
+		<xpath>*/ThingDef[defName="Bear_Polar"]/race</xpath>
 		<value>
 			<baseHealthScale>1.75</baseHealthScale>
 		</value>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Farm.xml
@@ -211,7 +211,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofblunt</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -222,7 +221,6 @@
 					<armorPenetration>0.102</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofpoke</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -233,7 +231,6 @@
 					<armorPenetration>0.075</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofblunt</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -244,7 +241,6 @@
 					<armorPenetration>0.102</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofpoke</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Poke</li>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Giant.xml
@@ -26,7 +26,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>tuskcut</id>
 					<label>tusk</label>
 					<capacities>
 						<li>Cut</li>
@@ -37,7 +36,6 @@
 					<armorPenetration>0.261</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>tuskstab</id>
 					<label>tusk</label>
 					<capacities>
 						<li>Stab</li>
@@ -180,7 +178,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>horncut</id>
 					<label>horn</label>
 					<capacities>
 						<li>Cut</li>
@@ -191,7 +188,6 @@
 					<armorPenetration>0.243</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>hornstab</id>
 					<label>horn</label>
 					<capacities>
 						<li>Stab</li>

--- a/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -27,7 +27,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofblunt</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -38,7 +37,6 @@
 					<armorPenetration>0.125</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofpoke</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -49,7 +47,6 @@
 					<armorPenetration>0.091</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofblunt</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -60,7 +57,6 @@
 					<armorPenetration>0.125</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofpoke</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -146,7 +142,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofblunt</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -157,7 +152,6 @@
 					<armorPenetration>0.11</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofpoke</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -168,7 +162,6 @@
 					<armorPenetration>0.08</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofblunt</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -179,7 +172,6 @@
 					<armorPenetration>0.11</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofpoke</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -265,7 +257,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofblunt</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -276,7 +267,6 @@
 					<armorPenetration>0.148</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofpoke</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -287,7 +277,6 @@
 					<armorPenetration>0.107</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofblunt</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -298,7 +287,6 @@
 					<armorPenetration>0.148</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofpoke</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -384,7 +372,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofblunt</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -395,7 +382,6 @@
 					<armorPenetration>0.148</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>lefthoofpoke</id>
 					<label>left hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -406,7 +392,6 @@
 					<armorPenetration>0.107</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofblunt</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Blunt</li>
@@ -417,7 +402,6 @@
 					<armorPenetration>0.148</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>righthoofpoke</id>
 					<label>right hoof</label>
 					<capacities>
 						<li>Poke</li>
@@ -503,7 +487,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>tuskcut</id>
 					<label>tusk</label>
 					<capacities>
 						<li>Cut</li>
@@ -514,7 +497,6 @@
 					<armorPenetration>0.121</armorPenetration>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>tuskstab</id>
 					<label>tusk</label>
 					<capacities>
 						<li>Stab</li>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -135,7 +135,6 @@
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
-					<id>leftbladecut</id>
 					<label>left blade</label>
 					<capacities>
 						<li>Cut</li>
@@ -147,7 +146,6 @@
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>leftbladestab</id>
 					<label>left blade</label>
 					<capacities>
 						<li>Stab</li>
@@ -159,7 +157,6 @@
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>rightbladecut</id>
 					<label>right blade</label>
 					<capacities>
 						<li>Cut</li>
@@ -171,7 +168,6 @@
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
 				<li Class="CombatExtended.ToolCE">
-					<id>rightbladestab</id>
 					<label>right blade</label>
 					<capacities>
 						<li>Stab</li>

--- a/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Medival.xml
+++ b/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Medival.xml
@@ -42,7 +42,6 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<id>limb</id>
 							<label>limb</label>
 							<capacities>
 								<li>Blunt</li>
@@ -53,7 +52,6 @@
 							<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>nock</id>
 							<label>nock</label>
 							<capacities>
 								<li>Poke</li>

--- a/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Modern.xml
+++ b/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Modern.xml
@@ -63,7 +63,6 @@
 							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -74,7 +73,6 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -142,7 +140,6 @@
 							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -153,7 +150,6 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -223,7 +219,6 @@
 							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -234,7 +229,6 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -302,7 +296,7 @@
 							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -313,7 +307,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -381,7 +375,7 @@
 							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -392,7 +386,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -461,7 +455,7 @@
 							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -472,7 +466,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -541,7 +535,7 @@
 							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -552,7 +546,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -621,7 +615,7 @@
 							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -632,7 +626,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -702,7 +696,7 @@
 							<linkedBodyPartsGroup>Magazine</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -713,7 +707,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -796,7 +790,7 @@
 							<linkedBodyPartsGroup>Magazine</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -807,7 +801,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -891,7 +885,7 @@
 							<linkedBodyPartsGroup>Magazine</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -902,7 +896,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -986,7 +980,7 @@
 							<linkedBodyPartsGroup>Magazine</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -997,7 +991,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1081,7 +1075,7 @@
 							<linkedBodyPartsGroup>Magazine</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1092,7 +1086,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1177,7 +1171,7 @@
 							<linkedBodyPartsGroup>Magazine</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1188,7 +1182,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1272,7 +1266,7 @@
 							<linkedBodyPartsGroup>Magazine</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1283,7 +1277,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1356,7 +1350,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1367,7 +1361,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1438,7 +1432,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1449,7 +1443,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1517,7 +1511,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1528,7 +1522,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1597,7 +1591,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1608,7 +1602,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1678,7 +1672,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1689,7 +1683,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1759,7 +1753,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1770,7 +1764,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1841,7 +1835,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1852,7 +1846,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -1923,7 +1917,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -1934,7 +1928,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2004,7 +1998,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2015,7 +2009,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2088,7 +2082,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2099,7 +2093,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2171,7 +2165,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2182,7 +2176,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2253,7 +2247,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2264,7 +2258,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2333,7 +2327,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2344,7 +2338,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2412,7 +2406,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2423,7 +2417,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2492,7 +2486,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2503,7 +2497,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2571,7 +2565,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2582,7 +2576,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2640,7 +2634,7 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2651,7 +2645,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2709,7 +2703,7 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2720,7 +2714,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2777,7 +2771,7 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2788,7 +2782,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2845,7 +2839,7 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2856,7 +2850,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -2917,7 +2911,6 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrels</id>
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -2989,7 +2982,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -3000,7 +2993,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -3071,7 +3064,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -3082,7 +3075,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -3153,7 +3146,7 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -3164,7 +3157,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -3223,7 +3216,7 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -3234,7 +3227,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -3292,7 +3285,7 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -3303,7 +3296,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -3361,7 +3354,7 @@
 				<value>
 					<tools>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
+							
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -3372,7 +3365,7 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
+							
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>

--- a/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Spacer.xml
+++ b/Patches/Rimfire/ThingDefs_Misc/RF_Ranged_Spacer.xml
@@ -56,7 +56,6 @@
 							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -67,7 +66,6 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -132,7 +130,6 @@
 							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -143,7 +140,6 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -204,7 +200,6 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -215,7 +210,6 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>
@@ -278,7 +272,6 @@
 							<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelblunt</id>
 							<label>barrel</label>
 							<capacities>
 								<li>Blunt</li>
@@ -289,7 +282,6 @@
 							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 						</li>
 						<li Class="CombatExtended.ToolCE">
-							<id>barrelpoke</id>
 							<label>muzzle</label>
 							<capacities>
 								<li>Poke</li>

--- a/Patches/VFWE/ThingDefs_Misc/Weapons_RangedNeolithic.xml
+++ b/Patches/VFWE/ThingDefs_Misc/Weapons_RangedNeolithic.xml
@@ -71,7 +71,7 @@
 				<weaponTags>
 					<li>CE_AI_Rifle</li>
 				</weaponTags>
-				<researchPrerequisite>Greatbows</researchPrerequisite>
+				<researchPrerequisite>Greatbow</researchPrerequisite>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>*/ThingDef[defName="Weapon_Crossbow"]/tools</xpath>


### PR DESCRIPTION
1. Replaced canBeSpawningInventory=false (b18) with
generateAllowChance=0 (1.0)
2. Replaced exceptedCategories (b18) with disallowedCategories (1.0)
3. Removed all instances of an <id> inside of a ToolCE (1.0 gives an XML
error for using <id>)