### PR TITLE
ShootingAccuracy is now ShootingAccuracyPawn and ShootingAccuracyTurret

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -93,7 +93,7 @@
       <Mass>20</Mass>
       <Bulk>25</Bulk>
       <AimingAccuracy>0.5</AimingAccuracy>
-      <ShootingAccuracy>1</ShootingAccuracy>
+      <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
     </statBases>
     <techLevel>Spacer</techLevel>
     <comps>
@@ -135,7 +135,7 @@
       <Mass>80</Mass>
       <Bulk>100</Bulk>
       <AimingAccuracy>0.5</AimingAccuracy>
-      <ShootingAccuracy>1</ShootingAccuracy>
+      <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
     </statBases>
     <techLevel>Spacer</techLevel>
     <description>Plated automatic turret with large caliber machine gun. Very resistant to damage.</description>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -93,7 +93,7 @@
       <Mass>20</Mass>
       <Bulk>25</Bulk>
       <AimingAccuracy>0.5</AimingAccuracy>
-      <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+      <ShootingAccuracyTurret>1</ShootingAccuracyTurret>
     </statBases>
     <techLevel>Spacer</techLevel>
     <comps>
@@ -135,7 +135,7 @@
       <Mass>80</Mass>
       <Bulk>100</Bulk>
       <AimingAccuracy>0.5</AimingAccuracy>
-      <ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+      <ShootingAccuracyTurret>1</ShootingAccuracyTurret>
     </statBases>
     <techLevel>Spacer</techLevel>
     <description>Plated automatic turret with large caliber machine gun. Very resistant to damage.</description>

--- a/Defs/ThingDefs_Misc/Apparel_Shield.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Shield.xml
@@ -54,7 +54,7 @@
     <equippedStatOffsets>
       <ReloadSpeed>-0.05</ReloadSpeed>
       <MeleeHitChance>-1</MeleeHitChance>
-      <ShootingAccuracy>-0.15</ShootingAccuracy>
+      <ShootingAccuracyPawn>-0.15</ShootingAccuracyPawn>
       <AimingAccuracy>-0.08</AimingAccuracy>
       <Suppressability>-0.25</Suppressability>
       <MeleeCritChance>-0.05</MeleeCritChance>
@@ -104,7 +104,7 @@
     <equippedStatOffsets>
       <ReloadSpeed>-0.2</ReloadSpeed>
       <MeleeHitChance>-4</MeleeHitChance>
-      <ShootingAccuracy>-0.4</ShootingAccuracy>
+      <ShootingAccuracyPawn>-0.4</ShootingAccuracyPawn>
       <AimingAccuracy>-0.2</AimingAccuracy>
       <Suppressability>-0.5</Suppressability>
       <MeleeCritChance>-0.2</MeleeCritChance>

--- a/Defs/ThingDefs_Plants/Plants_Cultivated_Farm.xml
+++ b/Defs/ThingDefs_Plants/Plants_Cultivated_Farm.xml
@@ -10,6 +10,7 @@
       <MaxHitPoints>65</MaxHitPoints>
       <Beauty>-1</Beauty>
       <Flammability>1</Flammability>
+	  <Nutrition>0.02</Nutrition>
     </statBases>
     <graphicData>
       <texPath>Things/Plant/Blazebulb</texPath>
@@ -20,7 +21,6 @@
     <ingestible>
       <foodType>Plant</foodType>
       <preferability>NeverForNutrition</preferability>
-      <Nutrition>0.02</Nutrition>
     </ingestible>
     <plant>
       <dieIfLeafless>true</dieIfLeafless>

--- a/Defs/ThingDefs_Plants/Plants_Cultivated_Farm.xml
+++ b/Defs/ThingDefs_Plants/Plants_Cultivated_Farm.xml
@@ -20,7 +20,7 @@
     <ingestible>
       <foodType>Plant</foodType>
       <preferability>NeverForNutrition</preferability>
-      <nutrition>0.02</nutrition>
+      <Nutrition>0.02</Nutrition>
     </ingestible>
     <plant>
       <dieIfLeafless>true</dieIfLeafless>

--- a/Patches/Apparello/ThingDefs/ApparelHats_Famous.xml
+++ b/Patches/Apparello/ThingDefs/ApparelHats_Famous.xml
@@ -75,7 +75,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>*/ThingDef[defName = "Apparello_Yi"]/equippedStatOffsets/ShootingAccuracy</xpath>
+				<xpath>*/ThingDef[defName = "Apparello_Yi"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 				<value>
 					<AimingAccuracy>0.05</AimingAccuracy>
 				</value>

--- a/Patches/Apparello/ThingDefs/ApparelHats_Various.xml
+++ b/Patches/Apparello/ThingDefs/ApparelHats_Various.xml
@@ -9,7 +9,7 @@
 			</li>
 			<!-- ========== Tac-team headcover ========== -->
 			<li Class="PatchOperationReplace">
-				<xpath>*/ThingDef[defName = "Apparello_Cyninja" or defName = "Apparello_Cybissar"]/equippedStatOffsets/ShootingAccuracy</xpath>
+				<xpath>*/ThingDef[defName = "Apparello_Cyninja" or defName = "Apparello_Cybissar"]/equippedStatOffsets/ShootingAccuracyPawn</xpath>
 				<value>
 					<AimingAccuracy>0.05</AimingAccuracy>
 				</value>

--- a/Patches/Apparello/ThingDefs/Apparel_Stuffed.xml
+++ b/Patches/Apparello/ThingDefs/Apparel_Stuffed.xml
@@ -80,7 +80,7 @@
 					<equippedStatOffsets>
 						<ReloadSpeed>-0.05</ReloadSpeed>
 						<MeleeHitChance>-0.05</MeleeHitChance>
-						<ShootingAccuracy>-0.05</ShootingAccuracy>
+						<ShootingAccuracyPawn>-0.05</ShootingAccuracyPawn>
 						<AimingAccuracy>-0.05</AimingAccuracy>
 						<Suppressability>-0.25</Suppressability>
 						<MeleeCritChance>-0.05</MeleeCritChance>

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -30,7 +30,7 @@
 		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.25</AimingAccuracy>
-			<ShootingAccuracyPawn>0.5</ShootingAccuracyPawn>
+			<ShootingAccuracyTurret>0.5</ShootingAccuracyTurret>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -30,7 +30,7 @@
 		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.25</AimingAccuracy>
-			<ShootingAccuracy>0.5</ShootingAccuracy>
+			<ShootingAccuracyPawn>0.5</ShootingAccuracyPawn>
 		</value>
 	</Operation>
 

--- a/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
+++ b/Patches/Core/ThingDefs_Misc/Apparel_Various.xml
@@ -170,7 +170,7 @@
 		<value>
 			<CarryWeight>80</CarryWeight>
 			<CarryBulk>10</CarryBulk>
-			<ShootingAccuracy>0.15</ShootingAccuracy>
+			<ShootingAccuracyPawn>0.15</ShootingAccuracyPawn>
 			<ToxicSensitivity>-0.50</ToxicSensitivity>
     </value>
   </Operation>

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -52,7 +52,7 @@
 			<CarryWeight>400</CarryWeight>
 			<CarryBulk>80</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracy>1</ShootingAccuracy>
+			<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.02</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.41</MeleeParryChance>
@@ -109,7 +109,7 @@
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>20</CarryBulk>
 			<AimingAccuracy>1.0</AimingAccuracy>
-			<ShootingAccuracy>2.6</ShootingAccuracy>
+			<ShootingAccuracyPawn>2.6</ShootingAccuracyPawn>
 			<MeleeDodgeChance>0.19</MeleeDodgeChance>
 			<MeleeCritChance>0.22</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>

--- a/Patches/Core/TraitDefs/Traits_Spectrum.xml
+++ b/Patches/Core/TraitDefs/Traits_Spectrum.xml
@@ -5,24 +5,24 @@
 		<success>Always</success>
 		<operations>
 			<li Class="PatchOperationRemove">
-				<xpath>*/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]/statOffsets/ShootingAccuracy</xpath>
+				<xpath>*/TraitDef[defName="ShootingAccuracyPawn"]/degreeDatas/li[label="careful shooter"]/statOffsets/ShootingAccuracyPawn</xpath>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>*/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="careful shooter"]</xpath>
+				<xpath>*/TraitDef[defName="ShootingAccuracyPawn"]/degreeDatas/li[label="careful shooter"]</xpath>
 				<value>
 					<statFactors>
-						<ShootingAccuracy>1.5</ShootingAccuracy>
+						<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 					</statFactors>
 				</value>
 			</li>
 			<li Class="PatchOperationRemove">
-				<xpath>*/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]/statOffsets/ShootingAccuracy</xpath>
+				<xpath>*/TraitDef[defName="ShootingAccuracyPawn"]/degreeDatas/li[label="trigger-happy"]/statOffsets/ShootingAccuracyPawn</xpath>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>*/TraitDef[defName="ShootingAccuracy"]/degreeDatas/li[label="trigger-happy"]</xpath>
+				<xpath>*/TraitDef[defName="ShootingAccuracyPawn"]/degreeDatas/li[label="trigger-happy"]</xpath>
 				<value>
 					<statFactors>
-						<ShootingAccuracy>0.5</ShootingAccuracy>
+						<ShootingAccuracyPawn>0.5</ShootingAccuracyPawn>
 					</statFactors>
 				</value>
 			</li>

--- a/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
+++ b/Patches/MechanoidsExtraordinaire/ThingDefs_Races/Races_Mechanoid_MechanoidsExtraordinaire.xml
@@ -22,7 +22,7 @@
 					<CarryWeight>55</CarryWeight>
 					<CarryBulk>22</CarryBulk>
 					<AimingAccuracy>1.0</AimingAccuracy>
-					<ShootingAccuracy>2.5</ShootingAccuracy>
+					<ShootingAccuracyPawn>2.5</ShootingAccuracyPawn>
 					<MeleeDodgeChance>0.25</MeleeDodgeChance>
 					<MeleeCritChance>0.25</MeleeCritChance>
 				</value>
@@ -81,7 +81,7 @@
 					<CarryWeight>350</CarryWeight>
 					<CarryBulk>100</CarryBulk>
 					<AimingAccuracy>0.8</AimingAccuracy>
-					<ShootingAccuracy>0.8</ShootingAccuracy>
+					<ShootingAccuracyPawn>0.8</ShootingAccuracyPawn>
 					<MeleeDodgeChance>0.05</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
 				</value>
@@ -140,7 +140,7 @@
 					<CarryWeight>380</CarryWeight>
 					<CarryBulk>120</CarryBulk>
 					<AimingAccuracy>1.0</AimingAccuracy>
-					<ShootingAccuracy>1.5</ShootingAccuracy>
+					<ShootingAccuracyPawn>1.5</ShootingAccuracyPawn>
 					<MeleeDodgeChance>0.10</MeleeDodgeChance>
 					<MeleeCritChance>0.15</MeleeCritChance>
 				</value>
@@ -199,7 +199,7 @@
 					<CarryWeight>550</CarryWeight>
 					<CarryBulk>140</CarryBulk>
 					<AimingAccuracy>0.5</AimingAccuracy>
-					<ShootingAccuracy>0.5</ShootingAccuracy>
+					<ShootingAccuracyPawn>0.5</ShootingAccuracyPawn>
 					<MeleeDodgeChance>0.15</MeleeDodgeChance>
 					<MeleeCritChance>0.50</MeleeCritChance>
 				</value>
@@ -258,7 +258,7 @@
 					<CarryWeight>750</CarryWeight>
 					<CarryBulk>200</CarryBulk>
 					<AimingAccuracy>1.5</AimingAccuracy>
-					<ShootingAccuracy>2.5</ShootingAccuracy>
+					<ShootingAccuracyPawn>2.5</ShootingAccuracyPawn>
 					<MeleeDodgeChance>0.15</MeleeDodgeChance>
 					<MeleeCritChance>0.40</MeleeCritChance>
 				</value>


### PR DESCRIPTION
ShootingAccuracy -> ShootingAccuracyPawn
nutrition -> Nutrition

Also this seems to be the Reason XML using CombatExtended.CompProperties_ExplosiveCE are broken:

Tried to use an uninitialized DefOf of type DamageDefOf. DefOfs are initialized right after all defs all loaded. Uninitialized DefOfs will return only nulls. (hint: don't use DefOfs as default field values in Defs, try to resolve them in ResolveReferences() instead) Debug info: DirectXmlToObject is currently instantiating an object of type CombatExtended.CompProperties_ExplosiveCE