### PR TITLE
Mechanoid parts of #532

### DIFF
--- a/Patches/Core/Bodies/Bodies_Mechanoid/Scyther.xml
+++ b/Patches/Core/Bodies/Bodies_Mechanoid/Scyther.xml
@@ -9,11 +9,11 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/groups</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/groups</xpath>
         <success>Invert</success>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart</xpath>
         <value>
           <groups />
         </value>
@@ -25,11 +25,11 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
         <success>Invert</success>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]</xpath>
         <value>
           <groups />
         </value>
@@ -41,11 +41,11 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]/groups</xpath>
         <success>Invert</success>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def = "MechanicalHead"]</xpath>
         <value>
           <groups />
         </value>
@@ -57,11 +57,11 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
         <success>Invert</success>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]</xpath>
         <value>
           <groups />
         </value>
@@ -73,11 +73,11 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
         <success>Invert</success>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]</xpath>
         <value>
           <groups />
         </value>
@@ -89,11 +89,11 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/groups</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/groups</xpath>
         <success>Invert</success>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]</xpath>
         <value>
           <groups />
         </value>
@@ -105,11 +105,11 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
         <success>Invert</success>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]</xpath>
         <value>
           <groups />
         </value>
@@ -121,11 +121,11 @@
     <success>Always</success>
     <operations>
       <li Class="PatchOperationTest">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
         <success>Invert</success>
       </li>
       <li Class="PatchOperationAdd">
-        <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
+        <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]</xpath>
         <value>
           <groups />
         </value>
@@ -136,56 +136,56 @@
   <!-- ========== Add armor coverage ========== -->
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/groups</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/parts/li[def = "MechanicalArm"]/parts/li[def = "MechanicalHand"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/parts/li[def = "MechanicalFoot"]/groups</xpath>
     <value>
       <li>CoveredByNaturalArmor</li>
     </value>
@@ -194,56 +194,56 @@
   <!-- ========== Modify coverage ========== -->
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/coverage</xpath>
     <value>
       <coverage>0.08</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/coverage</xpath>
     <value>
       <coverage>0.75</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "ArtificialBrain"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "ArtificialBrain"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SightSensor"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "HearingSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalNeck"]/parts/li[def="MechanicalHead"]/parts/li[def = "SmellSensor"]/coverage</xpath>
     <value>
       <coverage>0.05</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalShoulder"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalShoulder"]/coverage</xpath>
     <value>
       <coverage>0.15</coverage>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>/Defs/BodyDef[defName = "Scyther"]/corePart/parts/li[def = "MechanicalLeg"]/coverage</xpath>
+    <xpath>/Defs/BodyDef[defName = "Scyther" or defName = "Lancer"]/corePart/parts/li[def = "MechanicalLeg"]/coverage</xpath>
     <value>
       <coverage>0.1</coverage>
     </value>

--- a/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
+++ b/Patches/Core/HediffDefs/Hediffs_Local_AddedParts.xml
@@ -53,32 +53,5 @@
   		</value>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>*/HediffDef[defName="ScytherBlade"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>blade</label>
-					<capacities>
-						<li>Cut</li>
-					</capacities>
-					<power>20</power>
-					<cooldownTime>1.6</cooldownTime>
-					<armorPenetration>0.182</armorPenetration>
-					<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>point</label>
-					<capacities>
-						<li>Stab</li>
-					</capacities>
-					<power>12</power>
-					<cooldownTime>1.6</cooldownTime>
-					<armorPenetration>0.241</armorPenetration>
-					<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
-				</li>
-			</tools>
-  		</value>
-	</Operation>
 </Patch>
 

--- a/Patches/Core/PawnCapacityDefs/PawnCapacities.xml
+++ b/Patches/Core/PawnCapacityDefs/PawnCapacities.xml
@@ -2,22 +2,6 @@
 <Patch>
 
   <Operation Class="PatchOperationAdd">
-    <xpath>*/PawnCapacityDef[defName="BloodFiltration"]</xpath>
-    <value>
-      <labelMechanoids>capacitance</labelMechanoids>
-      <lethalMechanoids>true</lethalMechanoids>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationAdd">
-    <xpath>*/PawnCapacityDef[defName="BloodPumping"]</xpath>
-    <value>
-      <labelMechanoids>coolant pumping</labelMechanoids>
-      <lethalMechanoids>true</lethalMechanoids>
-    </value>
-  </Operation>
-
-  <Operation Class="PatchOperationAdd">
     <xpath>*/PawnCapacityDef[defName="Breathing"]</xpath>
     <value>
       <labelMechanoids>heat exchange</labelMechanoids>
@@ -28,13 +12,13 @@
   <Operation Class="PatchOperationAdd">
     <xpath>*/PawnCapacityDef[defName="Metabolism"]</xpath>
     <value>
-      <labelMechanoids>power generation</labelMechanoids>
+      <labelMechanoids>coolant reservoir</labelMechanoids>
       <lethalMechanoids>true</lethalMechanoids>
     </value>
   </Operation>
 
   <Operation Class="PatchOperationRemove">
-    <xpath>*/PawnCapacityDef[defName="BloodFiltration" or defName="BloodPumping" or defName="Breathing" or defName="Metabolism"]/showOnMechanoids</xpath>
+    <xpath>*/PawnCapacityDef[defName="Breathing" or defName="Metabolism"]/showOnMechanoids</xpath>
   </Operation>
 
 </Patch>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -3,19 +3,21 @@
 
 	<!-- ========== Mechanoid ========== -->
 
-  <Operation Class="PatchOperationRemove">
-  	<xpath>*/PawnKindDef[defName="Scyther"]/aiAvoidCover</xpath>
+  <Operation Class="PatchOperationAdd">
+  	<xpath>*/PawnKindDef[defName="Mech_Lancer"]</xpath>
+    <value>
+      <aiAvoidCover>false</aiAvoidCover>
+    </value>
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-  	<xpath>*/PawnKindDef[defName="Centipede"]/combatPower</xpath>
+  	<xpath>*/PawnKindDef[defName="Mech_Centipede"]/combatPower</xpath>
   	<value>
   		<combatPower>580</combatPower>
   	</value>
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">
-  	<xpath>*/PawnKindDef[defName="Scyther" or defName="Centipede"]</xpath>
   	<value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -18,6 +18,7 @@
   </Operation>
 
   <Operation Class="PatchOperationAddModExtension">
+  	<xpath>*/PawnKindDef[defName="Mech_Lancer" or defName="Mech_Centipede"]</xpath>
   	<value>
       <li Class="CombatExtended.LoadoutPropertiesExtension">
         <primaryMagazineCount>

--- a/Patches/Core/ResearchProjectDefs/ResearchProjects.xml
+++ b/Patches/Core/ResearchProjectDefs/ResearchProjects.xml
@@ -27,6 +27,15 @@
 			<researchViewY>0</researchViewY>
 		</value>
 	</Operation>
+	
+	<!-- Remove Sniper & Autoturret -->
+	<Operation Class="PatchOperationRemove">
+		<xpath>*/ResearchProjectDef[defName="HeavyTurrets"]</xpath>
+	</Operation>
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>*/ResearchProjectDef[defName="SniperTurret"]</xpath>
+	</Operation>
 
 </Patch>
 

--- a/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Patches/Core/ThingDefs_Buildings/Buildings_Security.xml
@@ -45,6 +45,10 @@
 		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
 	</Operation>
 
+	<Operation Class="PatchOperationRemove">
+		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/comps/li[@Class = "CompProperties_Refuelable"]</xpath>
+	</Operation>
+
 	<Operation Class="PatchOperationReplace">
 		<xpath>*/ThingDef[defName="Turret_MiniTurret"]/fillPercent</xpath>
 		<value>
@@ -119,106 +123,14 @@
 
 	<!-- ========== Sniper turret ========== -->
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Turret_Sniper"]/thingClass</xpath>
-		<value>
-			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Turret_Sniper"]/statBases/Mass</xpath>
-		<value>
-			<Mass>25</Mass>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationRemove">
-		<xpath>*/ThingDef[defName="Turret_Sniper"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Turret_Sniper"]/fillPercent</xpath>
-		<value>
-			<fillPercent>0.85</fillPercent>
-		</value>
-	</Operation>
-
-	<!-- Add trade tags -->
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/ThingDef[defName="Turret_Sniper"]/tradeTags</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/ThingDef[defName="Turret_Sniper"]</xpath>
-      	<value>
-        	<tradeTags />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="Turret_Sniper"]/tradeTags</xpath>
-		<value>
-			<li>CE_Turret</li>
-		</value>
+ 	<Operation Class="PatchOperationRemove">
+		<xpath>*/ThingDef[defName="Turret_Sniper"]</xpath>
 	</Operation>
 
 	<!-- ========== Autocannon turret ========== -->
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Turret_Autocannon"]/thingClass</xpath>
-		<value>
-			<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Turret_Autocannon"]/statBases/Mass</xpath>
-		<value>
-			<Mass>25</Mass>
-		</value>
-	</Operation>
-
 	<Operation Class="PatchOperationRemove">
-		<xpath>*/ThingDef[defName="Turret_Autocannon"]/comps/li[@Class = "CompProperties_Explosive"]</xpath>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Turret_Autocannon"]/fillPercent</xpath>
-		<value>
-			<fillPercent>0.85</fillPercent>
-		</value>
-	</Operation>
-
-	<!-- Add trade tags -->
-
-	<Operation Class="PatchOperationSequence">
-  	<success>Always</success>
-  	<operations>
-    	<li Class="PatchOperationTest">
-      	<xpath>*/ThingDef[defName="Turret_Autocannon"]/tradeTags</xpath>
-      	<success>Invert</success>
-    	</li>
-    	<li Class="PatchOperationAdd">
-      	<xpath>*/ThingDef[defName="Turret_Autocannon"]</xpath>
-      	<value>
-        	<tradeTags />
-      	</value>
-    	</li>
-  	</operations>
-	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="Turret_Autocannon"]/tradeTags</xpath>
-		<value>
-			<li>CE_Turret</li>
-		</value>
+		<xpath>*/ThingDef[defName="Turret_Autocannon"]</xpath>
 	</Operation>
 	
 	<!-- ========== Mortar Base ========== -->

--- a/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Patches/Core/ThingDefs_Races/Races_Mechanoid.xml
@@ -38,7 +38,7 @@
 	<!-- ========== Centipede ========== -->
 
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>*/ThingDef[defName="Mechanoid_Centipede"]</xpath>
+		<xpath>*/ThingDef[defName="Mech_Centipede"]</xpath>
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Quadruped</bodyShape>
@@ -47,7 +47,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="Mechanoid_Centipede"]/statBases</xpath>
+		<xpath>*/ThingDef[defName="Mech_Centipede"]/statBases</xpath>
 		<value>
 			<CarryWeight>400</CarryWeight>
 			<CarryBulk>80</CarryBulk>
@@ -60,21 +60,21 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Mechanoid_Centipede"]/statBases/ArmorRating_Blunt</xpath>
+		<xpath>*/ThingDef[defName="Mech_Centipede"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Mechanoid_Centipede"]/statBases/ArmorRating_Sharp</xpath>
+		<xpath>*/ThingDef[defName="Mech_Centipede"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>1</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Mechanoid_Centipede"]/tools</xpath>
+		<xpath>*/ThingDef[defName="Mech_Centipede"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -95,7 +95,7 @@
 	<!-- ========== Scyther ========== -->
 
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>*/ThingDef[defName="Mechanoid_Scyther"]</xpath>
+		<xpath>*/ThingDef[defName="Mech_Scyther" or defName="Mech_Lancer"]</xpath>
 		<value>
 			<li Class="CombatExtended.RacePropertiesExtensionCE">
 				<bodyShape>Humanoid</bodyShape>
@@ -104,7 +104,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>*/ThingDef[defName="Mechanoid_Scyther"]/statBases</xpath>
+		<xpath>*/ThingDef[defName="Mech_Scyther" or defName="Mech_Lancer"]/statBases</xpath>
 		<value>
 			<CarryWeight>50</CarryWeight>
 			<CarryBulk>20</CarryBulk>
@@ -117,21 +117,14 @@
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Mechanoid_Scyther"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>0.2</ArmorRating_Blunt>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Mechanoid_Scyther"]/statBases/ArmorRating_Sharp</xpath>
+		<xpath>*/ThingDef[defName="Mech_Scyther" or defName="Mech_Lancer"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Mechanoid_Scyther"]/tools</xpath>
+		<xpath>*/ThingDef[defName="Mech_Scyther"]/tools</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -176,6 +169,47 @@
 					<cooldownTime>1.65</cooldownTime>
 					<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
 					<armorPenetration>0.388</armorPenetration>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>head</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>7</power>
+					<cooldownTime>1.65</cooldownTime>
+					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+					<chanceFactor>0.2</chanceFactor>
+					<armorPenetration>0.095</armorPenetration>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>*/ThingDef[defName="Mech_Lancer"]/tools</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>left fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>1.65</cooldownTime>
+					<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+					<armorPenetration>0.095</armorPenetration>
+					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>right fist</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>12</power>
+					<cooldownTime>1.65</cooldownTime>
+					<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+					<armorPenetration>0.095</armorPenetration>
 					<alwaysTreatAsWeapon>true</alwaysTreatAsWeapon>
 				</li>
 				<li Class="CombatExtended.ToolCE">


### PR DESCRIPTION
- Bodies Scyther&Lancer the same
- ScytherBlade removed in 1.0
- BloodFiltr/BloodPump added in 1.0, Metabolism changed to "coolant
reservoir" flavour text
- Lancer (sniper) stops avoiding cover
- Lancer (sniper) and not Scyther (melee) have ammo
- Scyther/Lancer already have Blunt armor 0.2
- Lancer has fists/Hands instead of blades/Blades. Penetration value for
humanlike fists is used, and power value of 12 (vs human 9)