### PR TITLE
More error log entries

### DIFF
--- a/Patches/Core/FactionDefs/Factions_Misc.xml
+++ b/Patches/Core/FactionDefs/Factions_Misc.xml
@@ -13,7 +13,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>*/FactionDef[defName="Mechanoid"]/pawnGroupMakers/li[1]/options/Centipede</xpath>
     <value>
-      <Centipede>50</Centipede>
+      <Mech_Centipede>50</Mech_Centipede>
     </value>
   </Operation>
 

--- a/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -637,7 +637,7 @@
   </Operation>
 
   <Operation Class="PatchOperationReplace">
-    <xpath>*/PawnKindDef[defName="TribalChiefBase"]/weaponMoney</xpath>
+    <xpath>*/PawnKindDef[@Name="TribalChiefBase"]/weaponMoney</xpath>
     <value>
       <weaponMoney>
         <min>230</min>

--- a/Source/CombatExtended/CombatExtended/Comps/CompProperties_ExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompProperties_ExplosiveCE.cs
@@ -16,7 +16,7 @@ namespace CombatExtended
         public float fragSpeedFactor = 1f;
 
         public float explosionRadius = 0f;
-        public DamageDef explosionDamageDef = DamageDefOf.Bomb;
+        public DamageDef explosionDamageDef;
         // instigator
         public SoundDef soundExplode = null;
         // projectile = parent.def
@@ -33,5 +33,14 @@ namespace CombatExtended
         {
             compClass = typeof(CompExplosiveCE);
         }
+		
+		public override void ResolveReferences(ThingDef parentDef)
+		{
+			base.ResolveReferences(parentDef);
+			if (this.explosionDamageDef == null)
+			{
+				this.explosionDamageDef = DamageDefOf.Bomb;
+			}
+		}
     }
 }

--- a/Source/CombatExtended/CombatExtended/DefOfs/CE_MentalStateDefOf.cs
+++ b/Source/CombatExtended/CombatExtended/DefOfs/CE_MentalStateDefOf.cs
@@ -6,7 +6,6 @@ namespace CombatExtended
     [DefOf]
     public class CE_MentalStateDefOf
     {
-        public static MentalStateDef WanderOwnRoom;
         public static MentalStateDef ShellShock;
         public static MentalStateDef CombatFrenzy;
     }

--- a/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
+++ b/Source/CombatExtended/CombatExtended/SuppressionUtility.cs
@@ -125,7 +125,7 @@ namespace CombatExtended
                 || traits.DegreeOfTrait(TraitDefOf.Nerves) > 0
                 || traits.DegreeOfTrait((CE_TraitDefOf.Bravery)) > 1))
             {
-                breaks.Add(pawn.IsColonist?CE_MentalStateDefOf.WanderOwnRoom : MentalStateDefOf.PanicFlee);
+                breaks.Add(pawn.IsColonist? MentalStateDefOf.Wander_OwnRoom : MentalStateDefOf.PanicFlee);
                 breaks.Add(CE_MentalStateDefOf.ShellShock);
             }
 


### PR DESCRIPTION
- Centipede -> Mech_Centipede
- defName=TribalChiefBase -> @Name=TribalChiefBase
- MentalStateDefOf.Wander_OwnRoom exists in 1.0, removed from CE and
replaced where used
- Now, explosionDamageDef is set in ResolveReferences, as in vanilla