### PR TITLE
Reverting several commits and fixing errors

### DIFF
--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -51,7 +51,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>112</speed>
-			<!-- <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname> -->
+			<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -90,7 +90,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <speed>205</speed>
-      <!-- <dropsCasings>true</dropsCasings> -->
+      <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -90,7 +90,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <speed>250</speed>
-      <!-- <dropsCasings>true</dropsCasings> -->
+      <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -89,7 +89,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <speed>240</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+		<dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -89,7 +89,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <speed>228</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/HighCaliber/50BMG.xml
+++ b/Defs/Ammo/HighCaliber/50BMG.xml
@@ -105,7 +105,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageDef>Bullet</damageDef>
       <speed>222</speed>
-      <!-- <dropsCasings>true</dropsCasings> -->
+      <dropsCasings>true</dropsCasings>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Pistols/10mmAuto.xml
+++ b/Defs/Ammo/Pistols/10mmAuto.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>108</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/22LR.xml
+++ b/Defs/Ammo/Pistols/22LR.xml
@@ -73,7 +73,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>110</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 	

--- a/Defs/Ammo/Pistols/32ACP.xml
+++ b/Defs/Ammo/Pistols/32ACP.xml
@@ -87,7 +87,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>80</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>107</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/357SIG.xml
+++ b/Defs/Ammo/Pistols/357SIG.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>110</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/380ACP.xml
+++ b/Defs/Ammo/Pistols/380ACP.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>95</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/38Special.xml
+++ b/Defs/Ammo/Pistols/38Special.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>75</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/40Rimfire.xml
+++ b/Defs/Ammo/Pistols/40Rimfire.xml
@@ -58,7 +58,7 @@
 			<speed>33</speed>
 			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationBase>0.098</armorPenetrationBase>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Pistols/40SW.xml
+++ b/Defs/Ammo/Pistols/40SW.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>93</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/44Magnum.xml
+++ b/Defs/Ammo/Pistols/44Magnum.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>97</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -93,7 +93,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>135</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/45ACP.xml
+++ b/Defs/Ammo/Pistols/45ACP.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>78</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/45Colt.xml
+++ b/Defs/Ammo/Pistols/45Colt.xml
@@ -90,7 +90,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>70</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/46x30mm.xml
+++ b/Defs/Ammo/Pistols/46x30mm.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>150</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/500SWMagnum.xml
+++ b/Defs/Ammo/Pistols/500SWMagnum.xml
@@ -74,7 +74,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>122</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/762x25mmTokarev.xml
+++ b/Defs/Ammo/Pistols/762x25mmTokarev.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>131</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/762x38mmR.xml
+++ b/Defs/Ammo/Pistols/762x38mmR.xml
@@ -59,7 +59,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>83</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/763x25mmMauser.xml
+++ b/Defs/Ammo/Pistols/763x25mmMauser.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>110</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/8x22mmNambu.xml
+++ b/Defs/Ammo/Pistols/8x22mmNambu.xml
@@ -59,7 +59,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>73</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/9x18mmMakarov.xml
+++ b/Defs/Ammo/Pistols/9x18mmMakarov.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>80</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/9x19mmPara.xml
+++ b/Defs/Ammo/Pistols/9x19mmPara.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>95</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/FN57x28mm.xml
+++ b/Defs/Ammo/Pistols/FN57x28mm.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>163</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/127x55mmAR.xml
+++ b/Defs/Ammo/Rifle/127x55mmAR.xml
@@ -90,7 +90,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>79</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/127x55mmSniper.xml
+++ b/Defs/Ammo/Rifle/127x55mmSniper.xml
@@ -90,7 +90,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>79</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>213</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>186</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/30Carbine.xml
+++ b/Defs/Ammo/Rifle/30Carbine.xml
@@ -74,7 +74,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>152</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -59,7 +59,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>95</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>113</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>220</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 	

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>231</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -58,7 +58,7 @@
 			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationBase>0.466</armorPenetrationBase>
 			<speed>92</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
+++ b/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>193</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>200</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/75x54mmFrench.xml
+++ b/Defs/Ammo/Rifle/75x54mmFrench.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>208</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>180</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 	

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>210</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/762x54mmR.xml
+++ b/Defs/Ammo/Rifle/762x54mmR.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>207</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>185</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/792x33mmKurz.xml
+++ b/Defs/Ammo/Rifle/792x33mmKurz.xml
@@ -59,7 +59,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>171</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -59,7 +59,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>183</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -89,7 +89,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>80</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
+			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>
 	

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -195,8 +195,8 @@
       <soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
       <soundAmbient>MortarRound_Ambient</soundAmbient>
       <flyOverhead>true</flyOverhead>
-      <!-- <dropsCasings>true</dropsCasings> -->
-      <!-- <casingMoteDefname>Mote_BigShell</casingMoteDefname> -->
+      <dropsCasings>true</dropsCasings>
+      <casingMoteDefname>Mote_BigShell</casingMoteDefname>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -123,8 +123,8 @@
 			<speed>155</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 	  		<flyOverhead>false</flyOverhead>
-			<!-- <dropsCasings>true</dropsCasings> -->
-			<!-- <casingMoteDefname>Mote_BigShell</casingMoteDefname> -->
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Mote_BigShell</casingMoteDefname>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Shotgun/12Gauge.xml
+++ b/Defs/Ammo/Shotgun/12Gauge.xml
@@ -118,8 +118,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>101</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
-			<!-- <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname> -->
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -102,8 +102,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>83</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
-			<!-- <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname> -->
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
 		</projectile>
 	</ThingDef>
 	

--- a/Defs/Ammo/Shotgun/410Bore.xml
+++ b/Defs/Ammo/Shotgun/410Bore.xml
@@ -48,8 +48,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>70</speed>
-			<!-- <dropsCasings>true</dropsCasings> -->
-			<!-- <casingMoteDefname>Mote_ShotgunShell</casingMoteDefname> -->
+			<dropsCasings>true</dropsCasings>
+			<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -75,8 +75,8 @@
       <damageAmountBase>50</damageAmountBase>
       <explosionDelay>30</explosionDelay>
       <soundExplode>Explosion_Stun</soundExplode>
-      <!-- <dropsCasings>true</dropsCasings> -->
-      <!-- <casingMoteDefname>Mote_GrenadePin</casingMoteDefname> -->
+      <dropsCasings>true</dropsCasings>
+      <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
     </projectile>
   </ThingDef>
 
@@ -213,8 +213,8 @@
       <explosionRadius>4</explosionRadius>
       <damageDef>Smoke</damageDef>
       <explosionDelay>30</explosionDelay>
-      <!-- <dropsCasings>true</dropsCasings> -->
-      <!-- <casingMoteDefname>Mote_GrenadePin</casingMoteDefname> -->
+      <dropsCasings>true</dropsCasings>
+      <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
       <postExplosionSpawnThingDef>Gas_Smoke</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>
@@ -285,8 +285,8 @@
       <damageAmountBase>50</damageAmountBase>
       <damageDef>Extinguish</damageDef>
       <explosionDelay>30</explosionDelay>
-      <!-- <dropsCasings>true</dropsCasings> -->
-      <!-- <casingMoteDefname>Mote_GrenadePin</casingMoteDefname> -->
+      <dropsCasings>true</dropsCasings>
+      <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
       <postExplosionSpawnThingDef>Filth_FireFoam</postExplosionSpawnThingDef>
       <preExplosionSpawnChance>1</preExplosionSpawnChance>
     </projectile>

--- a/Patches/Core/Scenarios/Scenarios.xml
+++ b/Patches/Core/Scenarios/Scenarios.xml
@@ -37,5 +37,9 @@
 			</li>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>*/ScenarioDef/scenario/parts/li[@Class="ScenPart_StartingThing_Defined" and thingDef="Apparel_AdvancedHelmet"]/stuff</xpath>
+	</Operation>
 </Patch>
 

--- a/Patches/Core/Scenarios/Scenarios.xml
+++ b/Patches/Core/Scenarios/Scenarios.xml
@@ -41,5 +41,12 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>*/ScenarioDef/scenario/parts/li[@Class="ScenPart_StartingThing_Defined" and thingDef="Apparel_AdvancedHelmet"]/stuff</xpath>
 	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>*/ScenarioDef/scenario/parts/li[@Class="ScenPart_StartingThing_Defined" and thingDef="Apparel_FlakVest"]</xpath>
+		<value>
+			<stuff>Plasteel</stuff>
+		</value>
+	</Operation>
 </Patch>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -56,8 +56,8 @@
 			  <damageDef>Bomb</damageDef>
 			  <damageAmountBase>50</damageAmountBase>
 			  <explosionDelay>60</explosionDelay>
-			  <!-- <dropsCasings>true</dropsCasings> -->
-			  <!-- <casingMoteDefname>Mote_GrenadePin</casingMoteDefname> -->
+			  <dropsCasings>true</dropsCasings>
+			  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
       	<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			</projectile>
 		</value>
@@ -338,8 +338,8 @@
 			  <damageDef>EMP</damageDef>
 			  <damageAmountBase>40</damageAmountBase>
 			  <explosionDelay>60</explosionDelay>
-			  <!-- <dropsCasings>true</dropsCasings> -->
-			  <!-- <casingMoteDefname>Mote_GrenadePin</casingMoteDefname> -->
+			  <dropsCasings>true</dropsCasings>
+			  <casingMoteDefname>Mote_GrenadePin</casingMoteDefname>
 			</projectile>
 		</value>
 	</Operation>

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -280,7 +280,7 @@ namespace CombatExtended
             // ----------------------------------- STEP 5: Finalization
             
             var w = (newTargetLoc - sourceLoc);
-            shotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(-w.y, w.x) + rotationDegrees + spreadVec.x) % 360;
+            shotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(w.y, w.x) + rotationDegrees + spreadVec.x) % 360;
             shotAngle = angleRadians + spreadVec.y * Mathf.Deg2Rad;
         }
 

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -280,7 +280,7 @@ namespace CombatExtended
             // ----------------------------------- STEP 5: Finalization
             
             var w = (newTargetLoc - sourceLoc);
-            shotRotation = (90 + Mathf.Rad2Deg * Mathf.Atan2(-w.y, w.x) + rotationDegrees + spreadVec.x) % 360;
+            shotRotation = (-90 + Mathf.Rad2Deg * Mathf.Atan2(-w.y, w.x) + rotationDegrees + spreadVec.x) % 360;
             shotAngle = angleRadians + spreadVec.y * Mathf.Deg2Rad;
         }
 
@@ -587,7 +587,7 @@ namespace CombatExtended
                 resultingLine = default(ShootLine);
                 return false;
             }
-            if (this.verbProps.EffectiveMinRange(targ, this.caster) <= ShootTuning.MeleeRange) //This means we are in melee range!
+            if (this.verbProps.range <= ShootTuning.MeleeRange) // If this verb has a MAX range up to melee range (NOT a MIN RANGE!)
             {
                 resultingLine = new ShootLine(root, targ.Cell);
                 return ReachabilityImmediate.CanReachImmediate(root, targ, this.caster.Map, PathEndMode.Touch, null);
@@ -640,6 +640,7 @@ namespace CombatExtended
                 }
             }
             resultingLine = new ShootLine(root, targ.Cell);
+
             return false;
         }
 

--- a/Source/CombatExtended/Harmony/Harmony-TooltipUtility.cs
+++ b/Source/CombatExtended/Harmony/Harmony-TooltipUtility.cs
@@ -33,7 +33,7 @@ namespace CombatExtended.Harmony
                 if (verbCE != null)
                 {
                     stringBuilder.AppendLine();
-                    stringBuilder.Append("ShotBy".Translate(Find.Selector.SingleSelectedThing.LabelShort) + ":\n");
+                    stringBuilder.Append("ShotBy".Translate(Find.Selector.SingleSelectedThing.LabelShort, Find.Selector.SingleSelectedThing) + ":\n");
                     string obstructReport;
                     if (verbCE.CanHitTarget(target, out obstructReport))
                     {


### PR DESCRIPTION
- Reverted "casingMoteDefName doesn't exist anymore" and "dropsCasings
doesn't exist anymore" ---- Because they still exist
- Removed from Scenarios: "<stuff>" on Apparel_AdvancedHelmet, to have
no error on colony start
- Reverted change to Verb_LaunchProjectile.cs which caused anything with
minimum range below 1.42f (everything) to only check for shootlines
within a tile's distance.