### PR TITLE
Bullet, mote and graphics fixes

### DIFF
--- a/Defs/ThingDefs_Misc/Apparel_Various.xml
+++ b/Defs/ThingDefs_Misc/Apparel_Various.xml
@@ -127,7 +127,7 @@
         <li>Torso</li>
         <li>Shoulders</li>
       </bodyPartGroups>
-      <wornGraphicPath>Things/Pawn/Humanlike/Apparel/VestPlate/VestPlate</wornGraphicPath>
+      <wornGraphicPath>Things/Pawn/Humanlike/Apparel/FlakVest/FlakVest</wornGraphicPath>
       <layers>
         <li>Middle</li>
       </layers>

--- a/Defs/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Defs/ThingDefs_Misc/Weapons_Grenades.xml
@@ -69,7 +69,7 @@
       <texPath>Things/Projectile/Grenades/Flashbang</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
-    <projectile>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>3.5</explosionRadius>
       <damageDef>Stun</damageDef>
       <damageAmountBase>50</damageAmountBase>
@@ -209,7 +209,7 @@
       <texPath>Things/Projectile/Grenades/Smoke</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
-    <projectile>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>4</explosionRadius>
       <damageDef>Smoke</damageDef>
       <explosionDelay>30</explosionDelay>
@@ -280,7 +280,7 @@
       <texPath>Things/Projectile/Grenades/Firefoam</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
-    <projectile>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <explosionRadius>4</explosionRadius>
       <damageAmountBase>50</damageAmountBase>
       <damageDef>Extinguish</damageDef>

--- a/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Grenades.xml
@@ -51,7 +51,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>*/ThingDef[defName="Proj_GrenadeFrag"]/projectile</xpath>
 		<value>
-			<projectile>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			  <explosionRadius>1.5</explosionRadius>
 			  <damageDef>Bomb</damageDef>
 			  <damageAmountBase>50</damageAmountBase>
@@ -333,7 +333,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>*/ThingDef[defName="Proj_GrenadeEMP"]/projectile</xpath>
 		<value>
-			<projectile>
+			<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			  <explosionRadius>3</explosionRadius>
 			  <damageDef>EMP</damageDef>
 			  <damageAmountBase>40</damageAmountBase>

--- a/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/BulletCE.cs
@@ -93,10 +93,16 @@ namespace CombatExtended
             else
             {
                 SoundDefOf.BulletImpact_Ground.PlayOneShot(new TargetInfo(base.Position, map, false));
-                
-                //Only display a dirt hit for projectiles with a dropshadow
+
+                //Only display a dirt/water hit for projectiles with a dropshadow
                 if (base.castShadow)
-                	MoteMaker.MakeStaticMote(ExactPosition, map, ThingDefOf.Mote_ShotHit_Dirt, 1f);
+                { 
+                    MoteMaker.MakeStaticMote(this.ExactPosition, map, ThingDefOf.Mote_ShotHit_Dirt, 1f);
+                    if (base.Position.GetTerrain(map).takeSplashes)
+                    {
+                        MoteMaker.MakeWaterSplash(this.ExactPosition, map, Mathf.Sqrt(def.projectile.GetDamageAmount(this.launcher)) * 1f, 4f);
+                    }
+                }
             }
             base.Impact(hitThing);
         }

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -285,7 +285,7 @@ namespace CombatExtended
         {
             get
             {
-            	return Quaternion.AngleAxis(shotRotation, Vector3.up);
+            	return Quaternion.AngleAxis(shotRotation, Vector3.down);
             }
         }
         #endregion


### PR DESCRIPTION
- Shadow rotation (ExactRotation) fixed
- Added water hitting effect to BulletCE (as in vanilla 1.0)
- Added Class="CombatExtended.ProjectilePropertiesCE" to all grenades so
they can use the grenade pin mote
- Fixed the FlakVest image path