### PR TITLE
Charge Lance Availablity

### DIFF
--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1579,17 +1579,12 @@
 
 <!-- Disable Charge Lance for Player -->
 	<Operation Class="PatchOperationRemove">
-		<xpath>*/ThingDef[defName="Gun_ChargeLance"]/recipeMaker</xpath>
+		<xpath>/Defs/ThingDef[defName="Gun_ChargeLance"]/recipeMaker</xpath>
 	</Operation>
 
-	<Operation Class="PatchOperationReplace">
-		<xpath>*/ThingDef[defName="Gun_ChargeLance"]/weaponTags</xpath>
-			<value>
-				<weaponTags>
-				  <li>MechanoidGunMedium</li>
-				</weaponTags>
-			</value>
-	</Operation>	
+	<Operation Class="PatchOperationRemove">
+		<xpath>/Defs/ThingDef[defName="Gun_ChargeLance"]/weaponTags/li[contains(.,"SpacerGun")]</xpath>
+	</Operation>
 	
 </Patch>
 

--- a/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
+++ b/Patches/Core/ThingDefs_Misc/Weapons_Guns.xml
@@ -1577,5 +1577,19 @@
     </value>
   </Operation>
 
+<!-- Disable Charge Lance for Player -->
+	<Operation Class="PatchOperationRemove">
+		<xpath>*/ThingDef[defName="Gun_ChargeLance"]/recipeMaker</xpath>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>*/ThingDef[defName="Gun_ChargeLance"]/weaponTags</xpath>
+			<value>
+				<weaponTags>
+				  <li>MechanoidGunMedium</li>
+				</weaponTags>
+			</value>
+	</Operation>	
+	
 </Patch>
 


### PR DESCRIPTION
Disable ability to craft Charge Lance by deleting recipeMaker, and removed SpacerGun weaponTag to prevent traders from selling it.