### PR TITLE
Sphere Explosions and Combat log fix for cookoff

### DIFF
--- a/Defs/RulePackDefs/RulePacks_DamageEvent.xml
+++ b/Defs/RulePackDefs/RulePacks_DamageEvent.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+  <RulePackDef>
+    <defName>DamageEvent_CookOff</defName>
+    <include>
+      <li>DamageEvent_Include</li>
+    </include>
+    <rulePack>
+      <rulesStrings>
+        <li>damage_source->[cookoffbullet] jammed into</li>
+        <li>damage_source->[cookoffbullet] lodged into</li>
+        <li>damage_source->[cookoffbullet] struck</li>
+        <li>damage_source->[cookoffbullet] hit</li>
+        <li>damage_source->[cookoffbullet] pierced</li>
+        <li>damage_source->[cookoffbullet] graced</li>
+        <li>damage_source->[cookoffbullet] injured</li>
+        <li>damage_source->[cookoffbullet] hurt</li>
+
+        <li>cookoffbullet->a cooked off bullet</li>
+        <li>cookoffbullet->a cooked off round</li>
+        <li>cookoffbullet->exploding ammunition</li>
+        <li>cookoffbullet->ammo debris</li>
+        <li>cookoffbullet->bullet fragments</li>
+        <li>cookoffbullet->detonated rounds</li>
+        <li>cookoffbullet->a stray bullet</li>
+
+        <li>damaged_present->perforating</li>
+        <li>damaged_present->penetrating</li>
+        <li>damaged_present->damaging</li>
+		
+        <li>destroyed_present->shattering</li>
+        <li>destroyed_present->crushing</li>
+        <li>destroyed_present->obliterating</li>
+        <li>destroyed_present->annihilating</li>
+        <li>destroyed_present->piercing</li>
+        <li>destroyed_present->perforating</li>
+        <li>destroyed_present->puncturing</li>
+        <li>destroyed_present->tearing apart</li>
+        <li>destroyed_present->shredding</li>
+        <li>destroyed_present->eviscerating</li>
+      </rulesStrings>
+    </rulePack>
+  </RulePackDef>
+</Defs>

--- a/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompExplosiveCE.cs
@@ -51,17 +51,17 @@ namespace CombatExtended
                 float edificeHeight = (new CollisionVertical(posIV.GetEdifice(map))).Max;
                 Vector2 exactOrigin = new Vector2(pos.x, pos.z);
                 float height;
-                
-                //Fragments fly from a 0 to 45 degree angle away from the explosion
-                var range = new FloatRange(0, Mathf.PI / 8f);
+
+                //Fragments fly from a 0 (half of a circle) to 45 (3/4 of a circle) degree angle away from the explosion
+                var range = new FloatRange(0.5f, 0.75f);
                 
                 if (projCE != null)
                 {
                 	height = Mathf.Max(edificeHeight, pos.y);
                 	if (edificeHeight < height)
                 	{
-                		//If the projectile exploded above the ground, they can fly 45 degree away at the bottom as well
-                		range.min = -Mathf.PI / 8f;
+                        //If the projectile exploded above the ground, they can fly 45 degree away (1/4 of a circle) at the bottom as well
+                        range.min = 0.25f;
                 	}
                 	// TODO : Check for hitting the bottom or top of a roof
                 }
@@ -86,7 +86,7 @@ namespace CombatExtended
             			projectile.Launch(
             				instigator,
             				exactOrigin,
-            				range.RandomInRange,
+                            Mathf.Acos(2 * range.RandomInRange - 1),
             				UnityEngine.Random.Range(0, 360),
             				height,
             				Props.fragSpeedFactor * projectile.def.projectile.speed,

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -119,7 +119,7 @@ namespace CombatExtended
                 projectile.logMisses = false;
                 projectile.Launch(this,
                     new Vector2(DrawPos.x, DrawPos.z),
-                    UnityEngine.Random.Range(0, Mathf.PI / 2f),
+                    Mathf.Acos(2 * UnityEngine.Random.Range(0.5f, 1f) - 1),
                     UnityEngine.Random.Range(0, 360),
                     0.1f,
                     AmmoDef.cookOffProjectile.projectile.speed * AmmoDef.cookOffSpeed,


### PR DESCRIPTION
- Spherical explosions are now scaled by Acos(2*[0,1] - 1) to allow for
the correct sphere random direction generation. Without this change,
cooking off bullets would mostly emerge towards the top of the sphere.
- A combat log system for cook off projectiles has been added to fix
#570