### PR TITLE
Patch damage worker to not randomly preserve inner parts on destruction

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony-DamageWorker_AddInjury.cs
+++ b/Source/CombatExtended/Harmony/Harmony-DamageWorker_AddInjury.cs
@@ -87,4 +87,15 @@ namespace CombatExtended.Harmony
             }
         }
     }
+
+    [HarmonyPatch(typeof(DamageWorker_AddInjury), nameof(DamageWorker_AddInjury.ShouldReduceDamageToPreservePart))]
+    static class Patch_ShouldReduceDamageToPreservePart
+    {
+        [HarmonyPrefix]
+        static bool Prefix(bool __result, BodyPartRecord bodyPart)
+        {
+            __result = false;
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
Prevents the RNG from attempting to save inner core parts on destruction. Also stops inner core parts from being approximately 1.11x effective. Fixes #549 