### PR TITLE
Compatibility fix for LWM's DS, other storage mods

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony-FloatMenuMakerMap.cs
+++ b/Source/CombatExtended/Harmony/Harmony-FloatMenuMakerMap.cs
@@ -114,10 +114,9 @@ namespace CombatExtended.Harmony
             if (compInventory != null)
             {
                 List<Thing> thingList = c.GetThingList(pawn.Map);
-                if (!thingList.NullOrEmpty<Thing>())
+                foreach (Thing item in thingList)
                 {
-                    Thing item = thingList.FirstOrDefault(thing => thing.def.alwaysHaulable && !(thing is Corpse));
-                    if (item != null)
+                    if (item != null && item.def.alwaysHaulable && !(item is Corpse))
                     {
                         //FloatMenuOption pickUpOption;
                         int count = 0;


### PR DESCRIPTION
Allow picking up more than one item from storage unit.

See: https://github.com/NoImageAvailable/CombatExtended/issues/693