### PR TITLE
Misc fixes

### DIFF
--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -52,6 +52,7 @@
     <defaultBaseValue>1</defaultBaseValue>
     <minValue>0.001</minValue>
     <toStringStyle>PercentZero</toStringStyle>
+    <neverDisabled>true</neverDisabled>
     <showOnAnimals>false</showOnAnimals>
     <showOnMechanoids>true</showOnMechanoids>
     <skillNeedFactors>

--- a/Defs/ThingDefs_Buildings/Buildings_Defenses.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Defenses.xml
@@ -112,7 +112,7 @@
     <rotatable>false</rotatable>
     <selectable>true</selectable>
     <neverMultiSelect>true</neverMultiSelect>
-    <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
     <holdsRoof>true</holdsRoof>
     <designationCategory>Structure</designationCategory>
     <staticSunShadowHeight>1</staticSunShadowHeight>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -88,7 +88,7 @@
       <texPath>Things/Building/Turrets/MachineGunBase</texPath>
     </graphicData>
     <statBases>
-      <WorkToMake>48000</WorkToMake>
+      <WorkToBuild>48000</WorkToBuild>
       <MaxHitPoints>140</MaxHitPoints>
       <Mass>20</Mass>
       <Bulk>25</Bulk>
@@ -129,7 +129,7 @@
       <texPath>Things/Building/Turrets/MachineGunBase</texPath>
     </graphicData>
     <statBases>
-	  <WorkToMake>80000</WorkToMake>
+	  <WorkToBuild>80000</WorkToBuild>
       <MarketValue>2150</MarketValue>
       <MaxHitPoints>550</MaxHitPoints>
       <Flammability>0.05</Flammability>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -88,7 +88,7 @@
       <texPath>Things/Building/Turrets/MachineGunBase</texPath>
     </graphicData>
     <statBases>
-      <WorkToBuild>12000</WorkToBuild>
+      <WorkToBuild>48000</WorkToBuild>
       <MaxHitPoints>140</MaxHitPoints>
       <Mass>20</Mass>
       <Bulk>25</Bulk>
@@ -129,7 +129,7 @@
       <texPath>Things/Building/Turrets/MachineGunBase</texPath>
     </graphicData>
     <statBases>
-	  <WorkToBuild>20000</WorkToBuild>
+	  <WorkToBuild>80000</WorkToBuild>
       <MarketValue>2150</MarketValue>
       <MaxHitPoints>550</MaxHitPoints>
       <Flammability>0.05</Flammability>
@@ -262,7 +262,7 @@
     </graphicData>
     <statBases>
       <MaxHitPoints>500</MaxHitPoints>
-      <WorkToBuild>19875</WorkToBuild>
+      <WorkToBuild>79500</WorkToBuild>
       <Mass>1000</Mass>
       <Bulk>1000</Bulk>
     </statBases>

--- a/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Turrets.xml
@@ -88,7 +88,7 @@
       <texPath>Things/Building/Turrets/MachineGunBase</texPath>
     </graphicData>
     <statBases>
-      <WorkToBuild>48000</WorkToBuild>
+      <WorkToBuild>12000</WorkToBuild>
       <MaxHitPoints>140</MaxHitPoints>
       <Mass>20</Mass>
       <Bulk>25</Bulk>
@@ -129,7 +129,7 @@
       <texPath>Things/Building/Turrets/MachineGunBase</texPath>
     </graphicData>
     <statBases>
-	  <WorkToBuild>80000</WorkToBuild>
+	  <WorkToBuild>20000</WorkToBuild>
       <MarketValue>2150</MarketValue>
       <MaxHitPoints>550</MaxHitPoints>
       <Flammability>0.05</Flammability>
@@ -262,7 +262,7 @@
     </graphicData>
     <statBases>
       <MaxHitPoints>500</MaxHitPoints>
-      <WorkToMake>79500</WorkToMake>
+      <WorkToBuild>19875</WorkToBuild>
       <Mass>1000</Mass>
       <Bulk>1000</Bulk>
     </statBases>

--- a/Source/CombatExtended/CombatExtended/Gizmos/Command_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Gizmos/Command_Reload.cs
@@ -20,7 +20,7 @@ namespace CombatExtended
                 Log.Error("Command_Reload without ammo comp");
                 return;
             }
-            if (compAmmo.UseAmmo 
+            if (compAmmo.UseAmmo
                 && (compAmmo.CompInventory != null || compAmmo.turret != null)
                 || action == null)
             {
@@ -67,28 +67,29 @@ namespace CombatExtended
                 foreach (ThingDef curDef in ammoList)
                 {
                     AmmoDef ammoDef = (AmmoDef)curDef;
-                    floatOptionList.Add(new FloatMenuOption(ammoDef.ammoClass.LabelCap, new Action(delegate {
+                    floatOptionList.Add(new FloatMenuOption(ammoDef.ammoClass.LabelCap, new Action(delegate
+                    {
                         bool shouldReload = Controller.settings.AutoReloadOnChangeAmmo && (compAmmo.SelectedAmmo != ammoDef || compAmmo.CurMagCount < compAmmo.Props.magazineSize) && compAmmo.turret?.MannableComp == null;
-		               	compAmmo.SelectedAmmo = ammoDef;
-		               	if (shouldReload)
-		               	{
-			               	if (compAmmo.turret != null)
-			               	{
-			               		compAmmo.turret.TryOrderReload();
-			               	}
-			               	else
-			               	{
-			               		compAmmo.TryStartReload();
-			               	}
-		               	}
-	               	})));
+                        compAmmo.SelectedAmmo = ammoDef;
+                        if (shouldReload)
+                        {
+                            if (compAmmo.turret != null)
+                            {
+                                compAmmo.turret.TryOrderReload();
+                            }
+                            else
+                            {
+                                compAmmo.TryStartReload();
+                            }
+                        }
+                    })));
                 }
             }
             // Append unload command
             var hasOperator = compAmmo.Wielder != null || (compAmmo.turret?.MannableComp?.MannedNow ?? false);
             if (compAmmo.UseAmmo && hasOperator && compAmmo.HasMagazine && compAmmo.CurMagCount > 0)
             {
-                floatOptionList.Add(new FloatMenuOption("CE_UnloadLabel".Translate(), new Action(delegate { compAmmo.TryUnload(); })));
+                floatOptionList.Add(new FloatMenuOption("CE_UnloadLabel".Translate(), new Action(delegate { compAmmo.TryUnload(true); })));
             }
             // Append reload command
             if (compAmmo.HasMagazine && hasOperator)

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
@@ -142,8 +142,10 @@ namespace CombatExtended
             this.FailOn(HasNoGunOrAmmo);
 
             // Throw mote
-            if (compReloader.ShouldThrowMote)
+            if (compReloader.ShouldThrowMote && holder.Map != null)     //holder.Map is temporarily null after game load, skip mote if a pawn was reloading when game was saved
+            {
                 MoteMaker.ThrowText(pawn.Position.ToVector3Shifted(), holder.Map, string.Format("CE_ReloadingMote".Translate(), weapon.def.LabelCap));
+            }
 
             //Toil of do-nothing		
             Toil waitToil = new Toil() { actor = pawn }; // actor was always null in testing...

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_Reload.cs
@@ -44,7 +44,7 @@ namespace CombatExtended
         #endregion Properties
 
         #region Methods
-        
+
         /// <summary>
         /// Generates the string which is shown in the interface when a pawn is selected while they are performing this job.
         /// </summary>
@@ -71,16 +71,16 @@ namespace CombatExtended
         {
             //if (TargetThingB.DestroyedOrNull() || pawn.equipment == null || pawn.equipment.Primary == null || pawn.equipment.Primary != TargetThingB)
             if ((reloadingEquipment && (pawn?.equipment?.Primary == null || pawn.equipment.Primary != weapon))
-			   	|| (reloadingInventory && (pawn.inventory == null || !pawn.inventory.innerContainer.Contains(weapon)))
-			    || (initEquipment != pawn?.equipment?.Primary))
+                   || (reloadingInventory && (pawn.inventory == null || !pawn.inventory.innerContainer.Contains(weapon)))
+                || (initEquipment != pawn?.equipment?.Primary))
                 return true;
 
-			//CompAmmoUser comp = pawn.equipment.Primary.TryGetComp<CompAmmoUser>();
-			//return comp != null && comp.useAmmo && !comp.hasAmmo;
-			//return comp != null && !comp.hasAndUsesAmmoOrMagazine;
-			// expecting true ends the job.  if comp == null then will return false from the first part and not test the second.  Job will continue (bad).
+            //CompAmmoUser comp = pawn.equipment.Primary.TryGetComp<CompAmmoUser>();
+            //return comp != null && comp.useAmmo && !comp.hasAmmo;
+            //return comp != null && !comp.hasAndUsesAmmoOrMagazine;
+            // expecting true ends the job.  if comp == null then will return false from the first part and not test the second.  Job will continue (bad).
 
-			return compReloader == null || !compReloader.HasAndUsesAmmoOrMagazine;
+            return compReloader == null || !compReloader.HasAndUsesAmmoOrMagazine;
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace CombatExtended
             }
             if (weapon == null) // Required.
             {
-                Log.Error(errorBase +  "TargetThingB is null.  A weapon (ThingWithComps) is required to perform a reload.");
+                Log.Error(errorBase + "TargetThingB is null.  A weapon (ThingWithComps) is required to perform a reload.");
                 yield return null;
             }
             if (compReloader == null) // Required.
@@ -122,7 +122,7 @@ namespace CombatExtended
             }
             if (reloadingInventory && reloadingEquipment) // prevent incorrect information on job text.  If somehow this was true may cause a FailOn to trip.
             {
-                Log.Error(errorBase +  "Something went spectacularly wrong as the weapon to be reloaded was found in both the Pawn's equipment AND inventory at the same time.");
+                Log.Error(errorBase + "Something went spectacularly wrong as the weapon to be reloaded was found in both the Pawn's equipment AND inventory at the same time.");
                 yield return null;
             }
 

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_TakeFromOther.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_TakeFromOther.cs
@@ -26,7 +26,7 @@ namespace CombatExtended
 		private Thing targetItem
 		{
 			get {
-				return pawn.CurJob.GetTarget(thingInd).Thing;
+				return job.GetTarget(thingInd).Thing;
 			}
 		}
         /// <summary>
@@ -35,9 +35,10 @@ namespace CombatExtended
 		private Pawn takePawn
 		{
 			get {
-				return (Pawn)pawn.CurJob.GetTarget(sourceInd).Thing;
+				return (Pawn) job.GetTarget(sourceInd).Thing;
 			}
 		}
+
         /// <summary>
         /// Property which is used to indicate that the job was created with the expectation that the Pawn doing the job is to equip the thing they are taking.
         /// </summary>
@@ -50,7 +51,7 @@ namespace CombatExtended
 		{
 			get
 			{
-				return pawn.CurJob.GetTarget(flagInd).HasThing;
+				return job.GetTarget(flagInd).HasThing;
 			}
 		}
 
@@ -103,7 +104,16 @@ namespace CombatExtended
 			yield return Toils_Reserve.Reserve(sourceInd, int.MaxValue, 0, null);
 			yield return Toils_Goto.GotoThing(sourceInd, PathEndMode.Touch);
 			yield return Toils_General.Wait(10);
-			yield return new Toil {
+
+            if (targetItem is AmmoThing)
+            {
+                //For ammo items, this job is flagged with JobCondition.Incompletable, for unknown reasons.
+                //Removing the fail conditions allows the job to be carried out successfully, so the flag is likely being added by mistake at some point.
+                this.globalFailConditions.Clear();
+                //TODO : Find the root cause for ammo getting set as Incompletable
+            }
+
+            yield return new Toil {
 				initAction = delegate
 				{
                     // if the targetItem is no longer in the takePawn's inventory then another pawn already took it and we fail...

--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_TakeFromOther.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_TakeFromOther.cs
@@ -14,30 +14,32 @@ namespace CombatExtended
      * Need to check if the target still has the desired thing because if a pawn can take the entire stack then the thing object's container is changed rather than destroyed.
      * It's when a pawn takes a partial stack that new thing objects are created and the difference is deducted from the previously existing thing's stack count.
      */
-	public class JobDriver_TakeFromOther : JobDriver
-	{
-		private TargetIndex thingInd = TargetIndex.A;
-		private TargetIndex sourceInd = TargetIndex.B;
-		private TargetIndex flagInd = TargetIndex.C;
-		
+    public class JobDriver_TakeFromOther : JobDriver
+    {
+        private TargetIndex thingInd = TargetIndex.A;
+        private TargetIndex sourceInd = TargetIndex.B;
+        private TargetIndex flagInd = TargetIndex.C;
+
         /// <summary>
         /// Property that converts TargetIndex.A into a Thing object.
         /// </summary>
-		private Thing targetItem
-		{
-			get {
-				return job.GetTarget(thingInd).Thing;
-			}
-		}
+        private Thing targetItem
+        {
+            get
+            {
+                return job.GetTarget(thingInd).Thing;
+            }
+        }
         /// <summary>
         /// Property that converts TargetIndex.B into a Thing object.
         /// </summary>
 		private Pawn takePawn
-		{
-			get {
-				return (Pawn) job.GetTarget(sourceInd).Thing;
-			}
-		}
+        {
+            get
+            {
+                return (Pawn)job.GetTarget(sourceInd).Thing;
+            }
+        }
 
         /// <summary>
         /// Property which is used to indicate that the job was created with the expectation that the Pawn doing the job is to equip the thing they are taking.
@@ -48,25 +50,25 @@ namespace CombatExtended
         /// needed a way to store a bool value that could be saved into a Job.
         /// </remarks>
 		private bool doEquip
-		{
-			get
-			{
-				return job.GetTarget(flagInd).HasThing;
-			}
-		}
+        {
+            get
+            {
+                return job.GetTarget(flagInd).HasThing;
+            }
+        }
 
         /// <summary>
         /// Generates the Job Report string displayed when clicking on a pawn working on this job.
         /// </summary>
         /// <returns>string of the generated report.</returns>
 		public override string GetReport()
-		{
-			string text = CE_JobDefOf.TakeFromOther.reportString;
-			text = text.Replace("FlagC", doEquip ? "CE_TakeFromOther_Equipping".Translate() : "CE_TakeFromOther_Taking".Translate());
-			text = text.Replace("TargetA", targetItem.Label);
-			text = text.Replace("TargetB", takePawn.LabelShort);
-			return text;
-		}
+        {
+            string text = CE_JobDefOf.TakeFromOther.reportString;
+            text = text.Replace("FlagC", doEquip ? "CE_TakeFromOther_Equipping".Translate() : "CE_TakeFromOther_Taking".Translate());
+            text = text.Replace("TargetA", targetItem.Label);
+            text = text.Replace("TargetB", takePawn.LabelShort);
+            return text;
+        }
 
         /// <summary>
         /// A fail condition, if the takePawn is dead it no longer has a container.
@@ -76,7 +78,7 @@ namespace CombatExtended
         {
             return takePawn.Dead;
         }
-		
+
         /// <summary>
         /// Walks the linked list from a Thing's holdingOwner.Owner back up to a Pawn, or null, and returns the result.
         /// </summary>
@@ -95,15 +97,15 @@ namespace CombatExtended
         /// </summary>
         /// <returns>IEnumberable of Toil containing the sequence of actions the Pawn should take to fulfill the JobDriver's task.</returns>
 		protected override IEnumerable<Toil> MakeNewToils()
-		{
-			this.FailOnDespawnedNullOrForbidden(sourceInd);
+        {
+            this.FailOnDespawnedNullOrForbidden(sourceInd);
             this.FailOnDestroyedNullOrForbidden(thingInd);
             this.FailOn(DeadTakePawn);
             // We could set a slightly more sane value here which would prevent a hoard of pawns moving from pack animal to pack animal...
             // Also can enforce limits via JobGiver keeping track of how many things it's given away from each pawn, it's a small case though...
-			yield return Toils_Reserve.Reserve(sourceInd, int.MaxValue, 0, null);
-			yield return Toils_Goto.GotoThing(sourceInd, PathEndMode.Touch);
-			yield return Toils_General.Wait(10);
+            yield return Toils_Reserve.Reserve(sourceInd, int.MaxValue, 0, null);
+            yield return Toils_Goto.GotoThing(sourceInd, PathEndMode.Touch);
+            yield return Toils_General.Wait(10);
 
             if (targetItem is AmmoThing)
             {
@@ -113,9 +115,10 @@ namespace CombatExtended
                 //TODO : Find the root cause for ammo getting set as Incompletable
             }
 
-            yield return new Toil {
-				initAction = delegate
-				{
+            yield return new Toil
+            {
+                initAction = delegate
+                {
                     // if the targetItem is no longer in the takePawn's inventory then another pawn already took it and we fail...
                     if (takePawn == RootHolder(targetItem.holdingOwner.Owner))
                     {
@@ -127,14 +130,15 @@ namespace CombatExtended
                             if (compInventory != null)
                                 compInventory.TrySwitchToWeapon((ThingWithComps)targetItem);
                         }
-                    } else
+                    }
+                    else
                     {
                         this.EndJobWith(JobCondition.Incompletable);
                     }
-				}
-			};
+                }
+            };
             yield return Toils_Reserve.Release(sourceInd);
-		}
+        }
 
         public override bool TryMakePreToilReservations(bool errorOnFailed)
         {

--- a/Source/CombatExtended/CombatExtended/Things/IncendiaryFuel.cs
+++ b/Source/CombatExtended/CombatExtended/Things/IncendiaryFuel.cs
@@ -18,6 +18,12 @@ namespace CombatExtended
             List<Thing> list = new List<Thing>(Position.GetThingList(map));
             foreach (Thing thing in list)
             {
+                if (thing is Building_Door door && !door.Open)
+                {
+                    Destroy();
+                    return;
+                }
+
                 if (thing.HasAttachment(ThingDefOf.Fire))
                 {
                     Fire fire = (Fire)thing.GetAttachment(ThingDefOf.Fire);


### PR DESCRIPTION
- Fixed error log when non-violent colonists reload an auto-turret or a weapon they're carrying in inventory.
- Embrasures now have medium terrain affordance, to match solid walls.
- Heavy/charge auto-turret and 90mm construction no longer has a work amount of 1. Was caused by these being treated as a craftable instead of constructible.
- Incendiary fuel such as prometheum puddles can no longer spawn inside a closed door, as the puddle wouldn't be able to ignite until the door is opened.
- JobDriver_TakeFromOther was using pawn.CurJob to access targets, which caused errors if the job is temporarily kicked back into the queue (for example if the colonist starts vomiting). Using the job reference directly to avoid this.
- Added a functional workaround for #713, allowing the TakeFromOther job to work as intended when taking ammo.
- Weapons with ReloadOneAtATime can now resume reloading from a partially loaded state, instead of having to restart reloading from fully empty.
- Fixed issue with ReloadOneAtATime where shells already inside the weapon would be converted to a new type if the previous type runs out during a reload.
- Fixed error when game is saved then loaded while a pawn was reloading.