### PR TITLE
Fix #734, Fix #735

### DIFF
--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -863,6 +863,7 @@ namespace CombatExtended
             {
                 //Target is too far to hit with given velocity/range/gravity params
                 //set firing angle for maximum distance
+                Log.Warning("[CE] Tried to fire projectile to unreachable target cell, truncating to maximum distance.");
                 return 45.0f * Mathf.Deg2Rad;
             }
             return Mathf.Atan((Mathf.Pow(velocity, 2f) + (flyOverhead ? 1f : -1f) * squareRootCheck) / (gravity * range));

--- a/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Projectiles/ProjectileCE.cs
@@ -858,7 +858,14 @@ namespace CombatExtended
         /// <returns>Arc angle in radians off the ground.</returns>
         public static float GetShotAngle(float velocity, float range, float heightDifference, bool flyOverhead, float gravity)
         {
-            return Mathf.Atan((Mathf.Pow(velocity, 2f) + (flyOverhead ? 1f : -1f) * Mathf.Sqrt(Mathf.Pow(velocity, 4f) - gravity * (gravity * Mathf.Pow(range, 2f) + 2f * heightDifference * Mathf.Pow(velocity, 2f)))) / (gravity * range));
+            float squareRootCheck = Mathf.Sqrt(Mathf.Pow(velocity, 4f) - gravity * (gravity * Mathf.Pow(range, 2f) + 2f * heightDifference * Mathf.Pow(velocity, 2f)));
+            if (float.IsNaN(squareRootCheck))
+            {
+                //Target is too far to hit with given velocity/range/gravity params
+                //set firing angle for maximum distance
+                return 45.0f * Mathf.Deg2Rad;
+            }
+            return Mathf.Atan((Mathf.Pow(velocity, 2f) + (flyOverhead ? 1f : -1f) * squareRootCheck) / (gravity * range));
         }
         #endregion
 


### PR DESCRIPTION
ProjectileCE.GetShotAngle can potentially be given velocity/range/gravity parameters that make it impossible to resolve a firing angle, due to exceedingly large distances combined with slow velocity. Part of the formula will attempt to get the square root of a negative number, which turns the return value into NaN, causing an error when spawning the projectile.

Mortars in particular are affected, when fired across large distances by an inaccurate shooter. The fix detects the unresolvable formula and manually sets the angle to provide maximum range.