### PR TITLE
Allow manned turrets to be reloaded via haul job

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/WorkGiver_ReloadTurret.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/WorkGiver_ReloadTurret.cs
@@ -15,7 +15,7 @@ namespace CombatExtended
         {
             get
             {
-                return ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial); ;
+                return ThingRequest.ForGroup(ThingRequestGroup.BuildingArtificial);
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Building_TurretGunCE.cs
@@ -39,7 +39,7 @@ namespace CombatExtended
         private CompChangeableProjectile compChangeable = null;
         public bool isReloading = false;
         private int ticksUntilAutoReload = 0;
-        
+
         #endregion
 
         #region Properties
@@ -164,7 +164,7 @@ namespace CombatExtended
         {
             get
             {
-                return mannableComp == null
+                return (mannableComp == null || !mannableComp.MannedNow)
                     && CompAmmo != null
                     && CompAmmo.HasMagazine
                     && (CompAmmo.CurMagCount < CompAmmo.Props.magazineSize || CompAmmo.SelectedAmmo != CompAmmo.CurrentAmmo);
@@ -174,7 +174,8 @@ namespace CombatExtended
         {
             get
             {
-                return mannableComp == null && CompAmmo != null
+                return (mannableComp == null || (!mannableComp.MannedNow && ticksUntilAutoReload == 0))     //suppress manned turret auto-reload for a short time after spawning
+                    && CompAmmo != null
                     && CompAmmo.HasMagazine
                     && (ticksUntilAutoReload == 0 || CompAmmo.CurMagCount <= Mathf.CeilToInt(CompAmmo.Props.magazineSize / 6));
             }
@@ -423,6 +424,11 @@ namespace CombatExtended
             base.SpawnSetup(map, respawningAfterLoad);
             powerComp = base.GetComp<CompPowerTrader>();
             mannableComp = base.GetComp<CompMannable>();
+            if (mannableComp != null && !respawningAfterLoad)
+            {
+                //Delay auto-reload for a few seconds after spawn, so player can operate the turret right after placing it, before other colonists start reserving it for reload jobs
+                ticksUntilAutoReload = minTicksBeforeAutoReload;
+            }
         }
         
         private IAttackTargetSearcher TargSearcher()


### PR DESCRIPTION
Mannable turrets can be reloaded through hauling job or right-click context menu, as long as the turret isn't in use.