### PR TITLE
Added compatibility patches for Vanilla Apparel Expanded, tweaked and fixed compatibility patches for Vanilla Armour Expanded.

### DIFF
--- a/Patches/Vanilla Apparel Expanded/Patch_Apparel_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/Patch_Apparel_Industrial.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<!-- CJ: "Ah ####, here we go again." -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Vanilla Apparel Expanded</modName>
+			</li>
+
+			<!-- == VAE_Apparel_CasualTShirt, VAE_Apparel_ShirtandTie, VAE_Apparel_Trousers, VAE_Headgear_Fedora, VAE_Apparel_Overalls, VAE_Apparel_Hoodie and VAE_Apparel_FleeceShirt == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_CasualTShirt" or defName="VAE_Apparel_ShirtandTie" or defName="VAE_Apparel_Trousers" or defName="VAE_Headgear_Fedora" or defName="VAE_Apparel_Overalls" or defName="VAE_Apparel_Hoodie" or defName="VAE_Apparel_FleeceShirt"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_Shorts, VAE_Apparel_Skirt and VAE_Apparel_TankTop == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_Shorts" or defName="VAE_Apparel_Skirt" or defName="VAE_Apparel_TankTop"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>0.5</Bulk>
+					<StuffEffectMultiplierArmor>0.09</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_SuitJacket == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_SuitJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>0.3</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_Jeans and VAE_Apparel_Jumpsuit == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_Jeans" or defName="VAE_Apparel_Jumpsuit"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>1.5</Bulk>
+					<WornBulk>0.5</WornBulk>
+					<StuffEffectMultiplierArmor>0.24</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_ChefsUniform == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_ChefsUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>0.21</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_MilitaryJacket == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_MilitaryJacket"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>0.35</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_MilitaryUniform == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_MilitaryUniform"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>2</Bulk>
+					<WornBulk>0.5</WornBulk>
+					<StuffEffectMultiplierArmor>0.3</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_BuildersJacket == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
+					<ArmorRating_Sharp>0.12</ArmorRating_Sharp>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_BuildersJacket"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.2</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_LabCoat == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_LabCoat"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<Bulk>7.5</Bulk>
+					<WornBulk>1</WornBulk>
+					<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_SheriffShirt == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_SheriffShirt"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>0.16</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Apparel Expanded/Patch_Apparel_Medieval.xml
+++ b/Patches/Vanilla Apparel Expanded/Patch_Apparel_Medieval.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<!-- CJ: "Ah ####, here we go again." -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Vanilla Apparel Expanded</modName>
+			</li>
+
+			<!-- == VAE_Apparel_Tunic == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_Tunic"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>1.5</Bulk>
+					<WornBulk>0.5</WornBulk>
+					<StuffEffectMultiplierArmor>0.18</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_Blouse == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_Blouse"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>0.06</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_Apron == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_Apron"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>0.24</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_Cape == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_Cape"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>7.5</Bulk>
+					<WornBulk>1.5</WornBulk>
+					<StuffEffectMultiplierArmor>0.18</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Headgear_TrapperHat == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_TrapperHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>1.5</Bulk>
+					<StuffEffectMultiplierArmor>0.18</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Headgear_SummerHat == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_SummerHat"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Apparel Expanded/Patch_Apparel_Neolithic.xml
+++ b/Patches/Vanilla Apparel Expanded/Patch_Apparel_Neolithic.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<!-- CJ: "Ah ####, here we go again." -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Vanilla Apparel Expanded</modName>
+			</li>
+
+			<!-- == VAE_Apparel_PeltCoat == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_PeltCoat"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>7.5</Bulk>
+					<WornBulk>3</WornBulk>
+					<StuffEffectMultiplierArmor>0.3</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_TribalPoncho == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_TribalPoncho"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>4</Bulk>
+					<WornBulk>1</WornBulk>
+					<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Apparel_TribalKilt == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_TribalKilt"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>0.12</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Headgear_Hood == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_Hood"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<WornBulk>0.5</WornBulk>
+					<StuffEffectMultiplierArmor>0.12</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Apparel Expanded/Patch_Headgear_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/Patch_Headgear_Industrial.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<!-- CJ: "Ah ####, here we go again." -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Vanilla Apparel Expanded</modName>
+			</li>
+
+			<!-- == VAE_Headgear_Scarf == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_Scarf"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<Bulk>0.5</Bulk>
+					<StuffEffectMultiplierArmor>0.09</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+
+			<!-- == VAE_Headgear_Beret, VAE_Headgear_BaseballCap and VAE_Headgear_ChefsToque == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_Beret" or defName="VAE_Headgear_BaseballCap" or defName="VAE_Headgear_ChefsToque"]/statBases/StuffEffectMultiplierArmor</xpath>
+				<value>
+					<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+				</value>
+			</li>
+			<!-- Miscellaneous -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_Beret"]/equippedStatOffsets</xpath>
+				<value>
+					<equippedStatOffsets>
+						<AimingAccuracy>0.05</AimingAccuracy>
+					</equippedStatOffsets>
+				</value>
+			</li>
+
+			<!-- == VAE_Headgear_Hardhat == -->
+			<!-- statBases -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_Hardhat"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.48</ArmorRating_Blunt>
+				</value>
+			</li>
+
+			<!-- == VAE_Headgear_GasMask == -->
+			<!-- statBases -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_GasMask"]/statBases</xpath>
+				<value>
+					<Bulk>2</Bulk>
+					<WornBulk>1</WornBulk>
+				</value>
+			</li>
+			<!-- Miscellaneous -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_GasMask"]/equippedStatOffsets</xpath>
+				<value>
+					<AimingAccuracy>-0.1</AimingAccuracy>
+				</value>
+			</li>
+
+			<!-- == VAE_Headgear_Sunglasses and VAE_Headgear_Glasses == -->
+			<!-- statBases -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_Sunglasses" or defName="VAE_Headgear_Glasses"]/statBases</xpath>
+				<value>
+					<Bulk>0.5</Bulk>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Armour Expanded/Patch_Armor_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/Patch_Armor_Industrial.xml
@@ -39,12 +39,6 @@
 			</li>
 			<!-- Miscellaneous -->
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/label</xpath>
-				<value>
-					<label>bulletproof vest</label>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Apparel_BulletproofVest"]/description</xpath>
 				<value>
 					<description>A vest with kevlar plates inserted on the chest and back, which are reinforced with another fabric. Despite being cheaper and lighter than other defensive vests, it still offers some protection against gunfire.</description>

--- a/Patches/Vanilla Armour Expanded/Patch_Armor_Medieval.xml
+++ b/Patches/Vanilla Armour Expanded/Patch_Armor_Medieval.xml
@@ -17,12 +17,6 @@
 					<WornBulk>1</WornBulk>
 				</value>
 			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_Gambeson"]/statBases/StuffEffectMultiplierArmor</xpath>
-				<value>
-					<StuffEffectMultiplierArmor>0.28</StuffEffectMultiplierArmor>
-				</value>
-			</li>
 
 			<!-- == VAE_Apparel_QuiltedVest == -->
 			<!-- statBases -->
@@ -36,7 +30,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Apparel_QuiltedVest"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
-					<StuffEffectMultiplierArmor>0.32</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>0.26</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Vanilla Armour Expanded/Patch_Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/Patch_Armor_Spacer.xml
@@ -18,7 +18,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_LightMarineHelmet"]/MaxHitPoints</xpath>
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_LightMarineHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
@@ -77,7 +77,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_LightMarineArmor"]/MaxHitPoints</xpath>
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_LightMarineArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
 					<MaxHitPoints>500</MaxHitPoints>
 				</value>
@@ -131,7 +131,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/MaxHitPoints</xpath>
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
@@ -196,7 +196,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/MaxHitPoints</xpath>
+				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
 					<MaxHitPoints>500</MaxHitPoints>
 				</value>


### PR DESCRIPTION
Added patches for Vanilla Apparel Expanded (steamcommunity.com/sharedfiles/filedetails/?id=1814987817), fixed the broken xpaths in Patch_Armor_Spacer.xml which were causing the armor to remain unpatched, modified the stuff protection multipliers of some medieval armor.