### PR TITLE
Miscellaneous changes to 4 different mod compatibility patches.

### DIFF
--- a/Patches/Dragons!/ThingDefs_Races/Patch_Races_Animal_Dragons.xml
+++ b/Patches/Dragons!/ThingDefs_Races/Patch_Races_Animal_Dragons.xml
@@ -7,16 +7,19 @@
 			<li Class="CombatExtended.PatchOperationFindMod">
 				<modName>Dragon Mod</modName>
 			</li>
-			
-			<!-- Green_Dragon_Race -->
+
+			<!-- Adding shapes to the animals. -->
 			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Green_Dragon_Race"]</xpath>
+				<xpath>Defs/ThingDef[defName="Green_Dragon_Race" or defName="Black_Dragon_Race" or defName="Brown_Dragon_Race" or defName="Gold_Dragon_Race" or defName="Silver_Dragon_Race" or defName="Red_Dragon_Race" or defName="Blue_Dragon_Race" or defName="White_Dragon_Race" or defName="Purple_Dragon_Race" or defName="Cryo_Dragon_Race" or defName="Flamingo_Dragon_Race" or defName="Orange_Dragon_Race" or defName="Rock_Dragon_Race" or defName="Yellow_Dragon_Race" or defName="True_Dragon_Race" or defName="Royal_Dragon_Race" or defName="Basilisk_Race"]</xpath>
 				<value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
 						<bodyShape>Quadruped</bodyShape>
 					</li>
 				</value>
 			</li>
+
+			<!-- Giving the animals combat stats. -->
+			<!-- Green_Dragon_Race -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Green_Dragon_Race"]</xpath>
 				<value>
@@ -36,6 +39,114 @@
 					</statBases>
 				</value>
 			</li>
+			<!-- Black_Dragon_Race and Blue_Dragon_Race -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Black_Dragon_Race" or defName="Blue_Dragon_Race"]</xpath>
+				<value>
+					<statBases>
+						<MeleeDodgeChance>0.27</MeleeDodgeChance>
+						<MeleeCritChance>0.46</MeleeCritChance>
+						<MeleeParryChance>0.33</MeleeParryChance>
+						<MoveSpeed>8</MoveSpeed>
+						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
+						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
+						<ArmorRating_Heat>2</ArmorRating_Heat>
+						<ComfyTemperatureMax>70</ComfyTemperatureMax>
+						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
+						<MarketValue>4000</MarketValue>
+						<MeatAmount>140</MeatAmount>
+						<LeatherAmount>50</LeatherAmount>
+					</statBases>
+				</value>
+			</li>
+			<!-- Brown_Dragon_Race, Red_Dragon_Race, Purple_Dragon_Race, Orange_Dragon_Race and Yellow_Dragon_Race -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Brown_Dragon_Race" or defName="Red_Dragon_Race" or defName="Purple_Dragon_Race" or defName="Orange_Dragon_Race" or defName="Yellow_Dragon_Race"]</xpath>
+				<value>
+					<statBases>
+						<MeleeDodgeChance>0.27</MeleeDodgeChance>
+						<MeleeCritChance>0.43</MeleeCritChance>
+						<MeleeParryChance>0.3</MeleeParryChance>
+						<MoveSpeed>8</MoveSpeed>
+						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
+						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
+						<ArmorRating_Heat>2</ArmorRating_Heat>
+						<ComfyTemperatureMax>70</ComfyTemperatureMax>
+						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
+						<MarketValue>4000</MarketValue>
+						<MeatAmount>140</MeatAmount>
+						<LeatherAmount>50</LeatherAmount>
+					</statBases>
+				</value>
+			</li>
+			<!-- Gold_Dragon_Race, Silver_Dragon_Race, White_Dragon_Race and Cryo_Dragon_Race -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Gold_Dragon_Race" or defName="Silver_Dragon_Race" or defName="White_Dragon_Race" or defName="Cryo_Dragon_Race"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.27</MeleeDodgeChance>
+					<MeleeCritChance>0.43</MeleeCritChance>
+					<MeleeParryChance>0.3</MeleeParryChance>
+				</value>
+			</li>
+			<!-- Flamingo_Dragon_Race -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Flamingo_Dragon_Race"]</xpath>
+				<value>
+					<statBases>
+						<MeleeDodgeChance>0.27</MeleeDodgeChance>
+						<MeleeCritChance>0.43</MeleeCritChance>
+						<MeleeParryChance>0.29</MeleeParryChance>
+						<MoveSpeed>8</MoveSpeed>
+						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
+						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
+						<ArmorRating_Heat>2</ArmorRating_Heat>
+						<ComfyTemperatureMax>70</ComfyTemperatureMax>
+						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
+						<MarketValue>4000</MarketValue>
+						<MeatAmount>140</MeatAmount>
+						<LeatherAmount>50</LeatherAmount>
+					</statBases>
+				</value>
+			</li>
+			<!-- Rock_Dragon_Race -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Rock_Dragon_Race"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.15</MeleeDodgeChance>
+					<MeleeCritChance>0.26</MeleeCritChance>
+					<MeleeParryChance>0.33</MeleeParryChance>
+				</value>
+			</li>
+			<!-- Basilisk_Race -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Basilisk_Race"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.32</MeleeDodgeChance>
+					<MeleeCritChance>0.41</MeleeCritChance>
+					<MeleeParryChance>0.19</MeleeParryChance>
+				</value>
+			</li>
+			<!-- True_Dragon_Race -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="True_Dragon_Race"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.29</MeleeDodgeChance>
+					<MeleeCritChance>0.65</MeleeCritChance>
+					<MeleeParryChance>0.48</MeleeParryChance>
+				</value>
+			</li>
+			<!-- Royal_Dragon_Race -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Royal_Dragon_Race"]/statBases</xpath>
+				<value>
+					<MeleeDodgeChance>0.31</MeleeDodgeChance>
+					<MeleeCritChance>0.53</MeleeCritChance>
+					<MeleeParryChance>0.31</MeleeParryChance>
+				</value>
+			</li>
+
+			<!-- Unarmed attacks. -->
+			<!-- Green_Dragon_Race -->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Green_Dragon_Race"]/tools</xpath>
 				<value>
@@ -81,35 +192,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Black_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Black_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Black_Dragon_Race"]</xpath>
-				<value>
-					<statBases>
-						<MeleeDodgeChance>0.27</MeleeDodgeChance>
-						<MeleeCritChance>0.46</MeleeCritChance>
-						<MeleeParryChance>0.33</MeleeParryChance>
-						<MoveSpeed>8</MoveSpeed>
-						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
-						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
-						<ArmorRating_Heat>2</ArmorRating_Heat>
-						<ComfyTemperatureMax>70</ComfyTemperatureMax>
-						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
-						<MarketValue>4000</MarketValue>
-						<MeatAmount>140</MeatAmount>
-						<LeatherAmount>50</LeatherAmount>
-					</statBases>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Black_Dragon_Race"]/tools</xpath>
 				<value>
@@ -155,35 +238,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Brown_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Brown_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Brown_Dragon_Race"]</xpath>
-				<value>
-					<statBases>
-						<MeleeDodgeChance>0.27</MeleeDodgeChance>
-						<MeleeCritChance>0.43</MeleeCritChance>
-						<MeleeParryChance>0.3</MeleeParryChance>
-						<MoveSpeed>8</MoveSpeed>
-						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
-						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
-						<ArmorRating_Heat>2</ArmorRating_Heat>
-						<ComfyTemperatureMax>70</ComfyTemperatureMax>
-						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
-						<MarketValue>4000</MarketValue>
-						<MeatAmount>140</MeatAmount>
-						<LeatherAmount>50</LeatherAmount>
-					</statBases>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Brown_Dragon_Race"]/tools</xpath>
 				<value>
@@ -229,24 +284,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Gold_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Gold_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Gold_Dragon_Race"]/statBases</xpath>
-				<value>
-					<MeleeDodgeChance>0.27</MeleeDodgeChance>
-					<MeleeCritChance>0.43</MeleeCritChance>
-					<MeleeParryChance>0.3</MeleeParryChance>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Gold_Dragon_Race"]/tools</xpath>
 				<value>
@@ -292,24 +330,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Silver_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Silver_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Silver_Dragon_Race"]/statBases</xpath>
-				<value>
-					<MeleeDodgeChance>0.27</MeleeDodgeChance>
-					<MeleeCritChance>0.43</MeleeCritChance>
-					<MeleeParryChance>0.3</MeleeParryChance>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Silver_Dragon_Race"]/tools</xpath>
 				<value>
@@ -355,35 +376,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Red_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Red_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Red_Dragon_Race"]</xpath>
-				<value>
-					<statBases>
-						<MeleeDodgeChance>0.27</MeleeDodgeChance>
-						<MeleeCritChance>0.43</MeleeCritChance>
-						<MeleeParryChance>0.3</MeleeParryChance>
-						<MoveSpeed>8</MoveSpeed>
-						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
-						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
-						<ArmorRating_Heat>2</ArmorRating_Heat>
-						<ComfyTemperatureMax>70</ComfyTemperatureMax>
-						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
-						<MarketValue>4000</MarketValue>
-						<MeatAmount>140</MeatAmount>
-						<LeatherAmount>50</LeatherAmount>
-					</statBases>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Red_Dragon_Race"]/tools</xpath>
 				<value>
@@ -429,35 +422,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Blue_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Blue_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Blue_Dragon_Race"]</xpath>
-				<value>
-					<statBases>
-						<MeleeDodgeChance>0.27</MeleeDodgeChance>
-						<MeleeCritChance>0.46</MeleeCritChance>
-						<MeleeParryChance>0.33</MeleeParryChance>
-						<MoveSpeed>8</MoveSpeed>
-						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
-						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
-						<ArmorRating_Heat>2</ArmorRating_Heat>
-						<ComfyTemperatureMax>70</ComfyTemperatureMax>
-						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
-						<MarketValue>4000</MarketValue>
-						<MeatAmount>140</MeatAmount>
-						<LeatherAmount>50</LeatherAmount>
-					</statBases>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Blue_Dragon_Race"]/tools</xpath>
 				<value>
@@ -503,24 +468,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- White_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="White_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="White_Dragon_Race"]/statBases</xpath>
-				<value>
-					<MeleeDodgeChance>0.27</MeleeDodgeChance>
-					<MeleeCritChance>0.43</MeleeCritChance>
-					<MeleeParryChance>0.3</MeleeParryChance>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="White_Dragon_Race"]/tools</xpath>
 				<value>
@@ -566,35 +514,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Purple_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Purple_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Purple_Dragon_Race"]</xpath>
-				<value>
-					<statBases>
-						<MeleeDodgeChance>0.27</MeleeDodgeChance>
-						<MeleeCritChance>0.43</MeleeCritChance>
-						<MeleeParryChance>0.3</MeleeParryChance>
-						<MoveSpeed>8</MoveSpeed>
-						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
-						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
-						<ArmorRating_Heat>2</ArmorRating_Heat>
-						<ComfyTemperatureMax>70</ComfyTemperatureMax>
-						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
-						<MarketValue>4000</MarketValue>
-						<MeatAmount>140</MeatAmount>
-						<LeatherAmount>50</LeatherAmount>
-					</statBases>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Purple_Dragon_Race"]/tools</xpath>
 				<value>
@@ -640,24 +560,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Cryo_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Cryo_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Cryo_Dragon_Race"]/statBases</xpath>
-				<value>
-					<MeleeDodgeChance>0.27</MeleeDodgeChance>
-					<MeleeCritChance>0.43</MeleeCritChance>
-					<MeleeParryChance>0.3</MeleeParryChance>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Cryo_Dragon_Race"]/tools</xpath>
 				<value>
@@ -703,35 +606,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Flamingo_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Flamingo_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Flamingo_Dragon_Race"]</xpath>
-				<value>
-					<statBases>
-						<MeleeDodgeChance>0.27</MeleeDodgeChance>
-						<MeleeCritChance>0.43</MeleeCritChance>
-						<MeleeParryChance>0.29</MeleeParryChance>
-						<MoveSpeed>8</MoveSpeed>
-						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
-						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
-						<ArmorRating_Heat>2</ArmorRating_Heat>
-						<ComfyTemperatureMax>70</ComfyTemperatureMax>
-						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
-						<MarketValue>4000</MarketValue>
-						<MeatAmount>140</MeatAmount>
-						<LeatherAmount>50</LeatherAmount>
-					</statBases>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Flamingo_Dragon_Race"]/tools</xpath>
 				<value>
@@ -777,35 +652,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Orange_Dragon_Race-->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Orange_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Orange_Dragon_Race"]</xpath>
-				<value>
-					<statBases>
-						<MeleeDodgeChance>0.27</MeleeDodgeChance>
-						<MeleeCritChance>0.43</MeleeCritChance>
-						<MeleeParryChance>0.3</MeleeParryChance>
-						<MoveSpeed>8</MoveSpeed>
-						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
-						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
-						<ArmorRating_Heat>2</ArmorRating_Heat>
-						<ComfyTemperatureMax>70</ComfyTemperatureMax>
-						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
-						<MarketValue>4000</MarketValue>
-						<MeatAmount>140</MeatAmount>
-						<LeatherAmount>50</LeatherAmount>
-					</statBases>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Orange_Dragon_Race"]/tools</xpath>
 				<value>
@@ -851,24 +698,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Rock_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Rock_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Rock_Dragon_Race"]/statBases</xpath>
-				<value>
-					<MeleeDodgeChance>0.17</MeleeDodgeChance>
-					<MeleeCritChance>0.21</MeleeCritChance>
-					<MeleeParryChance>0.3</MeleeParryChance>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Rock_Dragon_Race"]/tools</xpath>
 				<value>
@@ -914,35 +744,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Yellow_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Yellow_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Yellow_Dragon_Race"]</xpath>
-				<value>
-					<statBases>
-						<MeleeDodgeChance>0.27</MeleeDodgeChance>
-						<MeleeCritChance>0.43</MeleeCritChance>
-						<MeleeParryChance>0.3</MeleeParryChance>
-						<MoveSpeed>8</MoveSpeed>
-						<ArmorRating_Blunt>0.65</ArmorRating_Blunt>
-						<ArmorRating_Sharp>0.45</ArmorRating_Sharp>
-						<ArmorRating_Heat>2</ArmorRating_Heat>
-						<ComfyTemperatureMax>70</ComfyTemperatureMax>
-						<ComfyTemperatureMin>-15</ComfyTemperatureMin>
-						<MarketValue>4000</MarketValue>
-						<MeatAmount>140</MeatAmount>
-						<LeatherAmount>50</LeatherAmount>
-					</statBases>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Yellow_Dragon_Race"]/tools</xpath>
 				<value>
@@ -988,35 +790,52 @@
 					</tools>
 				</value>
 			</li>
-			
-			<!-- True_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="True_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
+			<!-- Basilisk_Race -->
 			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="True_Dragon_Race"]/statBases</xpath>
+				<xpath>Defs/ThingDef[defName="Basilisk_Race"]/tools</xpath>
 				<value>
-					<statBases>
-						<MeleeDodgeChance>0.29</MeleeDodgeChance>
-						<MeleeCritChance>0.65</MeleeCritChance>
-						<MeleeParryChance>0.48</MeleeParryChance>
-						<MoveSpeed>8.5</MoveSpeed>
-						<ArmorRating_Blunt>1.2</ArmorRating_Blunt>
-						<ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-						<ArmorRating_Heat>3</ArmorRating_Heat>
-						<ComfyTemperatureMax>75</ComfyTemperatureMax>
-						<ComfyTemperatureMin>-30</ComfyTemperatureMin>
-						<MarketValue>6000</MarketValue>
-						<MeatAmount>140</MeatAmount>
-						<LeatherAmount>60</LeatherAmount>
-					</statBases>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>1.35</cooldownTime>
+							<power>12</power>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<linkedBodyPartsGroup>FrontLeftClaws</linkedBodyPartsGroup>
+							<label>left claw</label>
+							<armorPenetration>0.091</armorPenetration>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<cooldownTime>1.35</cooldownTime>
+							<power>12</power>
+							<capacities>
+								<li>Scratch</li>
+							</capacities>
+							<linkedBodyPartsGroup>FrontRightClaws</linkedBodyPartsGroup>
+							<label>right claw</label>
+							<armorPenetration>0.091</armorPenetration>
+						</li>
+						<li Class="CombatExtended.ToolCE">					
+							<cooldownTime>2</cooldownTime>
+							<power>15</power>
+							<capacities>
+								<li>Bite</li>
+							</capacities>
+							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
+							<surpriseAttack>
+								<extraMeleeDamages>
+									<li>
+										<def>Stun</def>
+										<amount>10</amount>
+									</li>
+								</extraMeleeDamages>
+							</surpriseAttack>
+							<armorPenetration>0.223</armorPenetration>
+						</li>
+					</tools>
 				</value>
 			</li>
+			<!-- True_Dragon_Race -->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="True_Dragon_Race"]/tools</xpath>
 				<value>
@@ -1062,24 +881,7 @@
 					</tools>
 				</value>
 			</li>
-			
 			<!-- Royal_Dragon_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Royal_Dragon_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Royal_Dragon_Race"]/statBases</xpath>
-				<value>
-					<MeleeDodgeChance>0.31</MeleeDodgeChance>
-					<MeleeCritChance>0.53</MeleeCritChance>
-					<MeleeParryChance>0.31</MeleeParryChance>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Royal_Dragon_Race"]/tools</xpath>
 				<value>
@@ -1125,80 +927,7 @@
 					</tools>
 				</value>
 			</li>
-			
-			<!-- Basilisk_Race -->
-			<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/ThingDef[defName="Basilisk_Race"]</xpath>
-				<value>
-					<li Class="CombatExtended.RacePropertiesExtensionCE">
-						<bodyShape>Quadruped</bodyShape>
-					</li>
-				</value>
-			</li>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="Basilisk_Race"]/statBases</xpath>
-				<value>
-					<MeleeDodgeChance>0.32</MeleeDodgeChance>
-					<MeleeCritChance>0.41</MeleeCritChance>
-					<MeleeParryChance>0.19</MeleeParryChance>
-				</value>
-			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/ThingDef[defName="Basilisk_Race"]/tools</xpath>
-				<value>
-					<tools>
-						<li Class="CombatExtended.ToolCE">
-							<cooldownTime>1.35</cooldownTime>
-							<power>12</power>
-							<capacities>
-								<li>Scratch</li>
-							</capacities>
-							<linkedBodyPartsGroup>FrontLeftClaws</linkedBodyPartsGroup>
-							<label>left claw</label>
-							<armorPenetration>0.091</armorPenetration>
-						</li>
-						<li Class="CombatExtended.ToolCE">
-							<cooldownTime>1.35</cooldownTime>
-							<power>12</power>
-							<capacities>
-								<li>Scratch</li>
-							</capacities>
-							<linkedBodyPartsGroup>FrontRightClaws</linkedBodyPartsGroup>
-							<label>right claw</label>
-							<armorPenetration>0.091</armorPenetration>
-						</li>
-						<li Class="CombatExtended.ToolCE">					
-							<cooldownTime>2</cooldownTime>
-							<power>15</power>
-							<capacities>
-								<li>Bite</li>
-							</capacities>
-							<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-							<surpriseAttack>
-								<extraMeleeDamages>
-									<li>
-										<def>Stun</def>
-										<amount>10</amount>
-									</li>
-								</extraMeleeDamages>
-							</surpriseAttack>
-							<armorPenetration>0.223</armorPenetration>
-						</li>
-					</tools>
-				</value>
-			</li>
 		</operations>
+
 	</Operation>
-	<!-- Dragons! + Ranged Animal Framework -->
-	<!--<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Dragon Mod</modName>
-			</li>
-			<li Class="CombatExtended.PatchOperationFindMod">
-				<modName>Range Animal Framework</modName>
-			</li>
-		</operations>
-	</Operation>-->
 </Patch>

--- a/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Armors.xml
+++ b/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Armors.xml
@@ -8,16 +8,11 @@
 			</li>
 			<!-- Using Combat Extended's vanilla Power Armor patch as a base -->
 			<!-- ==================================== Powered Assault Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases</xpath>
-				<value>
-					<Bulk>120</Bulk>
-					<WornBulk>18</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>120</Bulk>
+					<WornBulk>18</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -51,18 +46,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Engineer Power Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>108</Bulk>
-					<WornBulk>16.2</WornBulk>
+					<ArmorRating_Sharp>0.87</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.49</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Engineer Power Armor =====================================-->
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>108</Bulk>
+					<WornBulk>16.2</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -99,18 +101,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Explorer Power Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>100</Bulk>
-					<WornBulk>15</WornBulk>
+					<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.67</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Explorer Power Armor =====================================-->
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>100</Bulk>
+					<WornBulk>15</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -146,18 +155,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Grenadier Power Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>177.8</Bulk>
-					<WornBulk>26.7</WornBulk>
+					<ArmorRating_Sharp>0.67</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.36</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Grenadier Power Armor =====================================-->
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>177.8</Bulk>
+					<WornBulk>26.7</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -192,18 +208,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Commando Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>120</Bulk>
-					<WornBulk>18</WornBulk>
+					<ArmorRating_Sharp>1.1</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.69</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Commando Armor =====================================-->
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>120</Bulk>
+					<WornBulk>18</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -237,18 +260,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Hazard Operations Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>155.6</Bulk>
-					<WornBulk>23.3</WornBulk>
+					<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_CommandoArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.41</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Hazard Operations Armor =====================================-->
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>155.6</Bulk>
+					<WornBulk>23.3</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -284,18 +314,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Diplomat Power Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>120</Bulk>
-					<WornBulk>18</WornBulk>
+					<ArmorRating_Sharp>0.83</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.4</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Diplomat Power Armor =====================================-->
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>120</Bulk>
+					<WornBulk>18</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -331,18 +368,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Defender Power Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>132</Bulk>
-					<WornBulk>19.8</WornBulk>
+					<ArmorRating_Sharp>0.83</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Defender Power Armor =====================================-->
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>132</Bulk>
+					<WornBulk>19.8</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -379,18 +423,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Scout Power Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>106.67</Bulk>
-					<WornBulk>16</WornBulk>
+					<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.49</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Scout Power Armor =====================================-->
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>106.67</Bulk>
+					<WornBulk>16</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -426,18 +477,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Samurai Power Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>106.7</Bulk>
-					<WornBulk>16</WornBulk>
+					<ArmorRating_Sharp>0.78</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.49</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Samurai Power Armor =====================================-->
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>106.7</Bulk>
+					<WornBulk>16</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -474,19 +532,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Shock Trooper Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>106.7</Bulk>
-					<WornBulk>16</WornBulk>
+					<ArmorRating_Sharp>0.63</ArmorRating_Sharp>
 				</value>
 			</li>
-
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.31</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Shock Trooper Armor =====================================-->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>106.7</Bulk>
+					<WornBulk>16</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -524,18 +588,25 @@
 					<DevilstrandCloth>100</DevilstrandCloth>
 				</value>
 			</li>
-			
-			<!-- ==================================== Recon Power Armor =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/statBases</xpath>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<Bulk>84</Bulk>
-					<WornBulk>12.6</WornBulk>
+					<ArmorRating_Sharp>0.74</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.76</ArmorRating_Blunt>
+				</value>
+			</li>
+			
+			<!-- ==================================== Recon Power Armor =====================================-->
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>84</Bulk>
+					<WornBulk>12.6</WornBulk>
 					<MaxHitPoints>1200</MaxHitPoints>
 				</value>
 			</li>
@@ -571,6 +642,18 @@
 				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/costList</xpath>
 				<value>
 					<DevilstrandCloth>100</DevilstrandCloth>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/statBases/ArmorRating_Sharp</xpath>
+				<value>
+					<ArmorRating_Sharp>0.78</ArmorRating_Sharp>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmor"]/statBases/ArmorRating_Blunt</xpath>
+				<value>
+					<ArmorRating_Blunt>0.58</ArmorRating_Blunt>
 				</value>
 			</li>
 		</operations>

--- a/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Headgear.xml
+++ b/Patches/Spartan Foundry/ThingDefs_Misc/Patch_Apparel_Headgear.xml
@@ -9,16 +9,11 @@
 			<!-- Using Combat Extended's vanilla Power Armor Helmet patch as a base -->
 			
 			<!-- ==================================== Powered Assault Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_PoweredAssaultArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -41,16 +36,11 @@
 			</li>
 			
 			<!-- ==================================== Engineer Power Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>4.5</Bulk>
-					<WornBulk>0.9</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_EngineerPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>4.5</Bulk>
+					<WornBulk>0.9</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -75,16 +65,11 @@
 			</li>
 			
 			<!-- ==================================== Explorer Power Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ExplorerPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -108,16 +93,11 @@
 			</li>
 			
 			<!-- ==================================== Grenadier Power Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>5.6</Bulk>
-					<WornBulk>1.1</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_GrenadierPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>5.6</Bulk>
+					<WornBulk>1.1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -139,16 +119,11 @@
 			</li>
 			
 			<!-- ==================================== Commando Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_CommandoArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -171,16 +146,11 @@
 			</li>
 			
 			<!-- ==================================== Hazard Operations Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>5.6</Bulk>
-					<WornBulk>1.1</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_HazardOperationsArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>5.6</Bulk>
+					<WornBulk>1.1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -203,16 +173,11 @@
 			</li>
 			
 			<!-- ==================================== Diplomat Power Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DiplomatPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -237,16 +202,11 @@
 			</li>
 			
 			<!-- ==================================== Defender Power Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>4.5</Bulk>
-					<WornBulk>0.9</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_DefenderPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>4.5</Bulk>
+					<WornBulk>0.9</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -271,16 +231,11 @@
 			</li>
 			
 			<!-- ==================================== Scout Power Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ScoutPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -303,16 +258,11 @@
 			</li>
 			
 			<!-- ==================================== Samurai Power Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_SamuraiPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -337,16 +287,11 @@
 			</li>
 			
 			<!-- ==================================== Shock Trooper Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>5</Bulk>
-					<WornBulk>1</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ShockTrooperArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>5</Bulk>
+					<WornBulk>1</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>
@@ -371,16 +316,11 @@
 			</li>
 			
 			<!-- ==================================== Recon Power Armor Helmet =====================================-->
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmorHelmet"]/statBases</xpath>
-				<value>
-					<Bulk>4.5</Bulk>
-					<WornBulk>0.9</WornBulk>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="SF_ReconPowerArmorHelmet"]/statBases/MaxHitPoints</xpath>
 				<value>
+					<Bulk>4.5</Bulk>
+					<WornBulk>0.9</WornBulk>
 					<MaxHitPoints>240</MaxHitPoints>
 				</value>
 			</li>

--- a/Patches/Thrumkin/Patch_Implants_Prosthetics_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_Implants_Prosthetics_Thrumkin.xml
@@ -8,7 +8,7 @@
 			<li Class="CombatExtended.PatchOperationFindMod">
 				<modName>[SYR] Thrumkin</modName>
 			</li>
-			
+
 			<!-- SteelThrumkinHorn -->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/HediffDef[defName="SteelThrumkinHorn"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
@@ -27,7 +27,7 @@
 					</tools>
 				</value>
 			</li>
-			
+
 			<!-- EnhancementThrumkinHorn -->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/HediffDef[defName="EnhancementThrumkinHorn"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>

--- a/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_PawnKinds_Thrumkin.xml
@@ -15,7 +15,7 @@
 					<combatPower>20</combatPower>
 				</value>
 			</li>
-			
+
 			<!-- Thrumkin_Archer -->
 			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/PawnKindDef[defName="Thrumkin_Archer"]</xpath>

--- a/Patches/Thrumkin/Patch_Race_Thrumkin.xml
+++ b/Patches/Thrumkin/Patch_Race_Thrumkin.xml
@@ -27,7 +27,7 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>*/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases</xpath>
+				<xpath>Defs/AlienRace.ThingDef_AlienRace[defName = "Thrumkin"]/statBases</xpath>
 				<value>
 					<AimingAccuracy>0.9</AimingAccuracy>
 					<MeleeCritChance>1.3</MeleeCritChance>

--- a/Patches/Vanilla Apparel Expanded/Patch_Apparel_Industrial.xml
+++ b/Patches/Vanilla Apparel Expanded/Patch_Apparel_Industrial.xml
@@ -76,7 +76,7 @@
 				<value>
 					<Bulk>2</Bulk>
 					<WornBulk>0.5</WornBulk>
-					<StuffEffectMultiplierArmor>0.3</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>0.21</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 

--- a/Patches/Vanilla Apparel Expanded/Patch_Apparel_Medieval.xml
+++ b/Patches/Vanilla Apparel Expanded/Patch_Apparel_Medieval.xml
@@ -15,7 +15,7 @@
 				<value>
 					<Bulk>1.5</Bulk>
 					<WornBulk>0.5</WornBulk>
-					<StuffEffectMultiplierArmor>0.18</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>0.14</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 


### PR DESCRIPTION
Those 4 mods are: Thrumkin, RimWorld - Spartan Foundry, Vanilla Apparel Expanded and Dragon mod (Dragons!).

EDIT: The changes for the mods are:

- Thrumkin - removed unnecessary space and changed an xpath to be faster.

- RimWorld - Spartan Foundry - made the armor values of the armor more similar to CE power armor. Their protectionwas previously unpatched. At the same time debloated them by condensing xpaths of helmet and armor patches.

- Vanilla Apparel Expanded - changed some stuff protection multipliers for better or for worse.

- Dragon mod - debloated the entire patch.