### PR TITLE
Obscure colony start fix #2

### DIFF
--- a/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/LoadoutPropertiesExtension.cs
@@ -210,7 +210,8 @@ namespace CombatExtended
                 if(cur.Price < money
                     && shieldTags.Any(t => cur.thing.apparel.tags.Contains(t))
                     && (cur.thing.generateAllowChance >= 1f || Rand.ValueSeeded(pawn.thingIDNumber ^ 68715844) <= cur.thing.generateAllowChance)
-                    && pawn.apparel.CanWearWithoutDroppingAnything(cur.thing))
+                    && pawn.apparel.CanWearWithoutDroppingAnything(cur.thing)
+                    && ApparelUtility.HasPartsToWear(pawn, cur.thing))
                 {
                     workingShields.Add(cur);
                 }


### PR DESCRIPTION
Fix for ancient danger "Halfeaten" pawns spawning without arms, then
their loadout adding a shield and a warning telling us they can't wear
the shield because they don't have arms