### PR TITLE
Gun recipes now contain " (ammoSet.Label)" and the Ammo recipe description is expanded

### DIFF
--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -84,6 +84,8 @@ namespace CombatExtended
                 //.. else, continue the method.
             }
 
+            AddRemoveCaliberFromGunRecipes();
+
             var ammoDefs = new HashSet<ThingDef>();
 
             // Find all ammo using guns
@@ -243,6 +245,35 @@ namespace CombatExtended
                 }
             }
             _allRecipesCached.SetValue(benchDef, null);  // Set ammoCraftingStation.AllRecipes to null so it will reset
+        }
+
+        public static bool gunRecipesShowCaliber = false;
+        public static void AddRemoveCaliberFromGunRecipes()
+        {
+            var shouldHaveLabels = (Controller.settings.EnableAmmoSystem && Controller.settings.ShowCaliberOnGuns);
+
+            if (gunRecipesShowCaliber != shouldHaveLabels)
+            {
+                CE_Utility.allWeaponDefs.ForEach(x =>
+                {
+                    var ammoSet = x.GetCompProperties<CompProperties_AmmoUser>()?.ammoSet;
+
+                    if (ammoSet != null)
+                    {
+                        RecipeDef recipeDef = DefDatabase<RecipeDef>.GetNamed("Make_" + x.defName, false);
+
+                        if (recipeDef != null)
+                        {
+                            var label = x.label + (shouldHaveLabels ? " (" + ammoSet.LabelCap + ")" : "");
+
+                            recipeDef.UpdateLabel("RecipeMake".Translate(label));           //Just setting recipeDef.label doesn't update Jobs nor existing recipeUsers. We need UpdateLabel.
+                            recipeDef.jobString = "RecipeMakeJobString".Translate(label);   //The jobString should also be updated to reflect the name change.
+                        }
+                    }
+                });
+
+                gunRecipesShowCaliber = shouldHaveLabels;
+            }
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -116,6 +116,10 @@ namespace CombatExtended
                 ammoDef.menuHidden = !enabled;
                 ammoDef.destroyOnDrop = !enabled;
 
+                //AFTER CE_Utility.allWeaponDefs is initiated, this sets each ammo to list its users & special effects in its DEF DESCRIPTION rather than its THING DESCRIPTION.
+                //This is because the THING description ISN'T available during crafting - so people can now figure out what's different between ammo types.
+                ammoDef.AddDescriptionParts();
+
                 // Toggle trading
                 if (ammoDef.tradeTags.Contains(enableTradeTag))
                 {

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -117,11 +117,6 @@ namespace CombatExtended
 
         public static void UpdateLabel(this Def def, string label)
         {
-            if (label.NullOrEmpty())
-            {
-                Log.Error("ERROR: GunMod.UpdateLabel(this Def def, string label) was called with label.NullOrEmpty() for def \"" + def.defName + "\"");
-                return;
-            }
             def.label = label;
             cachedLabelCapInfo.SetValue(def, "");
         }

--- a/Source/CombatExtended/CombatExtended/CE_Utility.cs
+++ b/Source/CombatExtended/CombatExtended/CE_Utility.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Reflection;
 using RimWorld;
 using Verse;
 using Verse.AI;
@@ -111,6 +112,19 @@ namespace CombatExtended
     	
         #region Misc
         public static List<ThingDef> allWeaponDefs = new List<ThingDef>();
+
+        public static readonly FieldInfo cachedLabelCapInfo = typeof(Def).GetField("cachedLabelCap", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        public static void UpdateLabel(this Def def, string label)
+        {
+            if (label.NullOrEmpty())
+            {
+                Log.Error("ERROR: GunMod.UpdateLabel(this Def def, string label) was called with label.NullOrEmpty() for def \"" + def.defName + "\"");
+                return;
+            }
+            def.label = label;
+            cachedLabelCapInfo.SetValue(def, "");
+        }
 
         /// <summary>
         /// Generates a random Vector2 in a circle with given radius

--- a/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
@@ -34,5 +34,34 @@ namespace CombatExtended
                 return users;
             }
         }
+
+        private string oldDescription;
+        public void AddDescriptionParts()
+        {
+            if (ammoClass != null)
+            {
+                if (oldDescription.NullOrEmpty())
+                    oldDescription = description;
+
+                StringBuilder stringBuilder = new StringBuilder();
+                stringBuilder.AppendLine(oldDescription);
+
+                // Append ammo class description
+                stringBuilder.AppendLine("\n" + ammoClass.LabelCap + ":");
+                stringBuilder.AppendLine(ammoClass.description);
+
+                // Append guns that use this caliber
+                if (!Users.NullOrEmpty())
+                {
+                    stringBuilder.AppendLine("\n" + "CE_UsedBy".Translate() + ":");
+                    foreach (var user in Users)
+                    {
+                        stringBuilder.AppendLine("   -" + user.LabelCap);
+                    }
+                }
+
+                description = stringBuilder.ToString().TrimEndNewlines();
+            }
+        }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Settings.cs
+++ b/Source/CombatExtended/CombatExtended/Settings.cs
@@ -161,8 +161,13 @@ namespace CombatExtended
             if (lastAmmoSystemStatus != enableAmmoSystem)
             {
                 AmmoInjector.Inject();
+                AmmoInjector.AddRemoveCaliberFromGunRecipes();  //Ensure the labels are _removed_ when the ammo system gets disabled
                 lastAmmoSystemStatus = enableAmmoSystem;
                 TutorUtility.DoModalDialogIfNotKnown(CE_ConceptDefOf.CE_AmmoSettings);
+            }
+            else if (AmmoInjector.gunRecipesShowCaliber != showCaliberOnGuns)
+            {
+                AmmoInjector.AddRemoveCaliberFromGunRecipes();
             }
         }
 

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -21,7 +21,7 @@ namespace CombatExtended
 
         #region Methods
 
-        public override string DescriptionFlavor
+      /*public override string DescriptionFlavor
         {
             get
             {
@@ -50,7 +50,7 @@ namespace CombatExtended
 
                 return base.DescriptionFlavor;
             }
-        }
+        }*/
 
         public override void PreApplyDamage(ref DamageInfo dinfo, out bool absorbed)
         {


### PR DESCRIPTION
- Added UpdateLabel() function from Rimfire to update recipe names,
while deleting existing Job names' old recipe names (Reflection)

- Ensured Settings switches names behind guns in recipes when the toggle
is switched

- AmmoInjector now contains AddRemoveCaliberFromGunRecipes() which
checks whether names should be added or removed based on
CE_Utility.allWeaponDefs.

- AmmoInjector (e.g AFTER CE_Utility.allWeaponDefs is initiated) sets ammo descriptions to include AmmoCategoryDef stuff

- AmmoDef.AddDescriptionParts now contains what was usually in AmmoThing.DescriptionFlavor