### PR TITLE
Additional stat displays in ranged/melee recipes and ammoThings

### DIFF
--- a/Defs/Stats/Stats_Basics_Inventory.xml
+++ b/Defs/Stats/Stats_Basics_Inventory.xml
@@ -11,5 +11,15 @@
     <toStringStyle>FloatTwo</toStringStyle>
     <displayPriorityInCategory>10</displayPriorityInCategory>
   </StatDef>
+  
+  <StatDef>
+    <defName>AmmoSet</defName>
+    <workerClass>CombatExtended.StatWorker_AmmoSet</workerClass>
+    <label>ammo set</label>
+    <description>The guns which accept this type of ammo.</description>
+    <category>BasicsNonPawn</category>
+    <showIfUndefined>true</showIfUndefined>
+    <displayPriorityInCategory>898</displayPriorityInCategory>
+  </StatDef>
 
 </Defs>

--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -171,6 +171,7 @@
     <Compile Include="CombatExtended\SightUtility.cs" />
     <Compile Include="CombatExtended\StatWorkers\StatWorker_BodyPartDensity.cs" />
     <Compile Include="CombatExtended\StatWorkers\StatWorker_Caliber.cs" />
+    <Compile Include="CombatExtended\StatWorkers\StatWorker_AmmoSet.cs" />
     <Compile Include="CombatExtended\StatWorkers\StatWorker_MeleeArmorPenetration.cs" />
     <Compile Include="CombatExtended\StatWorkers\StatWorker_Magazine.cs" />
     <Compile Include="CombatExtended\TexButton.cs" />

--- a/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
+++ b/Source/CombatExtended/CombatExtended/Defs/AmmoDef.cs
@@ -34,5 +34,17 @@ namespace CombatExtended
                 return users;
             }
         }
+
+        private List<AmmoSetDef> ammoSetDefs;
+        public List<AmmoSetDef> AmmoSetDefs
+        {
+            get
+            {
+                if (ammoSetDefs == null)
+                    ammoSetDefs = users.Select(x => x.GetCompProperties<CompProperties_AmmoUser>().ammoSet).Distinct().ToList();
+
+                return ammoSetDefs;
+            }
+        }
     }
 }

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_AmmoSet.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_AmmoSet.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RimWorld;
+using Verse;
+
+namespace CombatExtended
+{
+    public class StatWorker_AmmoSet : StatWorker
+    {
+        public override bool ShouldShowFor(StatRequest req)
+        {
+            return base.ShouldShowFor(req) && (!(req.Def as AmmoDef)?.Users.NullOrEmpty() ?? false);
+        }
+
+        public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            var ammoDef = (req.Def as AmmoDef);
+
+            if (ammoDef != null)
+            {
+                var users = ammoDef.Users;
+
+                if (!users.NullOrEmpty())
+                {
+                    var ammoSetDefs = ammoDef.AmmoSetDefs;
+                    var count = ammoSetDefs.Count;
+
+                    foreach (var ammoSet in ammoSetDefs)
+                    {
+                        var launcherNameArray = users.Where(x => count == 1 || x.GetCompProperties<CompProperties_AmmoUser>()?.ammoSet == ammoSet)
+                                            .Select(y => y.label.CapitalizeFirst())
+                                            .ToArray();
+
+                        var projectile = ammoSet.ammoTypes.Find(x => x.ammo == (req.Def as AmmoDef)).projectile;
+
+                        stringBuilder.AppendLine(ammoSet.LabelCap + " (" + string.Join(", ", launcherNameArray) + "):\n"
+                            + projectile.GetProjectileReadout(null));   //Is fine handling req.Thing == null, then it sets mult = 1
+                    }
+                }
+            }
+
+            return stringBuilder.ToString().TrimEndNewlines();
+        }
+
+        public override string GetStatDrawEntryLabel(StatDef stat, float value, ToStringNumberSense numberSense, StatRequest optionalReq)
+        {
+            var list = (optionalReq.Def as AmmoDef)?.AmmoSetDefs;
+            return list.FirstOrDefault().LabelCap + (list.Count > 1 ? " (+"+list.Count+")" : "");
+        }
+    }
+}

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Caliber.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Caliber.cs
@@ -12,7 +12,7 @@ namespace CombatExtended
     {
         public override bool ShouldShowFor(StatRequest req)
         {
-            return base.ShouldShowFor(req) && req.Thing?.TryGetComp<CompAmmoUser>()?.Props.ammoSet != null;
+            return base.ShouldShowFor(req) && (req.Def as ThingDef)?.GetCompProperties<CompProperties_AmmoUser>()?.ammoSet != null;
         }
 
         public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)
@@ -26,7 +26,7 @@ namespace CombatExtended
                 foreach (var cur in ammoProps.ammoSet.ammoTypes)
                 {
                     string label = string.IsNullOrEmpty(cur.ammo.ammoClass.LabelCapShort) ? cur.ammo.ammoClass.LabelCap : cur.ammo.ammoClass.LabelCapShort;
-                    stringBuilder.AppendLine(label + ":\n" + cur.projectile.GetProjectileReadout(req.Thing));
+                    stringBuilder.AppendLine(label + ":\n" + cur.projectile.GetProjectileReadout(req.Thing));   //Is fine handling req.Thing == null, then it sets mult = 1
                 }
             }
             return stringBuilder.ToString().TrimEndNewlines();

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Magazine.cs
@@ -12,12 +12,12 @@ namespace CombatExtended
     {
         public override bool ShouldShowFor(StatRequest req)
         {
-            return base.ShouldShowFor(req) && req.Thing?.TryGetComp<CompAmmoUser>()?.Props.magazineSize > 0;
+            return base.ShouldShowFor(req) && ((req.Def as ThingDef)?.GetCompProperties<CompProperties_AmmoUser>()?.magazineSize ?? 0) > 0;
         }
 
         public override float GetValueUnfinalized(StatRequest req, bool applyPostProcess = true)
         {
-            return req.Thing?.TryGetComp<CompAmmoUser>().Props.magazineSize ?? 0;
+            return (req.Def as ThingDef)?.GetCompProperties<CompProperties_AmmoUser>()?.magazineSize ?? 0;
         }
 
         public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeArmorPenetration.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeArmorPenetration.cs
@@ -12,14 +12,14 @@ namespace CombatExtended
     {
         private float GetMeleePenetration(StatRequest req)
         {
-            var tools = req.Thing?.def.tools;
+            var tools = (req.Def as ThingDef)?.tools;
             if (tools.NullOrEmpty())
             {
                 return 0;
             }
             if (tools.Any(x=> !(x is ToolCE)))
             {
-                Log.Error($"Trying to get stat MeleePenetration from {req.Thing.def.defName} which has no support for Combat Extended.");
+                Log.Error($"Trying to get stat MeleePenetration from {req.Def.defName} which has no support for Combat Extended.");
                 return 0;
             }
 
@@ -34,7 +34,7 @@ namespace CombatExtended
                 var weightFactor = tool.chanceFactor / totalSelectionWeight;
                 totalAveragePen += weightFactor * tool.armorPenetration;
             }
-            var penMult = req.Thing.GetStatValue(CE_StatDefOf.MeleePenetrationFactor);
+            var penMult = req.Thing?.GetStatValue(CE_StatDefOf.MeleePenetrationFactor) ?? 1f;
             return totalAveragePen * penMult;
         }
 
@@ -45,14 +45,16 @@ namespace CombatExtended
 
         public override string GetExplanationUnfinalized(StatRequest req, ToStringNumberSense numberSense)
         {
-            if (req.Thing?.def.tools.NullOrEmpty() ?? true)
+            var tools = (req.Def as ThingDef)?.tools;
+
+            if (tools.NullOrEmpty())
             {
                 return base.GetExplanationUnfinalized(req, numberSense);
             }
 
             var stringBuilder = new StringBuilder();
-            var penMult = req.Thing.GetStatValue(CE_StatDefOf.MeleePenetrationFactor);
-            foreach (ToolCE tool in req.Thing.def.tools)
+            var penMult = req.Thing?.GetStatValue(CE_StatDefOf.MeleePenetrationFactor) ?? 1f;
+            foreach (ToolCE tool in tools)
             {
                 var maneuvers = DefDatabase<ManeuverDef>.AllDefsListForReading.Where(d => tool.capacities.Contains(d.requiredCapacity));
                 var maneuverString = "(";


### PR DESCRIPTION
- Display Caliber in the information box in Bills (req.Def as ThingDef
instead of req.Thing.Def)

- Display magazine in Bill info box (req.Def as ThingDef instead of
req.Thing.Def)

- Display CORRECT melee armor penetration in Bill info box
(req.Thing.(..).MeleePenetrationFactor ?? 1f to default to 1f)

- Display AmmoSetDefs (Guns) which an AmmoThing (or AmmoDef) can be used
in, using StatDef Ammoset.