### PR TITLE
Make FSX, Prometheum and Flamethrower ammo explosive #753

### DIFF
--- a/Defs/Ammo/Flamethrower.xml
+++ b/Defs/Ammo/Flamethrower.xml
@@ -50,6 +50,15 @@
       <MarketValue>0.3</MarketValue>
     </statBases>
     <ammoClass>IncendiaryFuel</ammoClass>
+    <comps>
+      <li Class="CombatExtended.CompProperties_ExplosiveCE">
+		<explosionDamage>2</explosionDamage>
+        <explosionDamageDef>PrometheumFlame</explosionDamageDef>
+        <explosionRadius>1</explosionRadius>
+		<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
+		<preExplosionSpawnChance>1</preExplosionSpawnChance>
+      </li>
+    </comps>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="FlamethrowerBase">
@@ -63,6 +72,15 @@
       <MarketValue>0.7</MarketValue>
     </statBases>
     <ammoClass>IncendiaryFuel</ammoClass>
+    <comps>
+      <li Class="CombatExtended.CompProperties_ExplosiveCE">
+		<explosionDamage>5</explosionDamage>
+        <explosionDamageDef>PrometheumFlame</explosionDamageDef>
+        <explosionRadius>1.2</explosionRadius>
+		<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+		<preExplosionSpawnChance>1</preExplosionSpawnChance>
+      </li>
+    </comps>
   </ThingDef>
 	
 	<!-- ================== Projectiles ================== -->

--- a/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
+++ b/Defs/ThingDefs_Items/Items_Resource_Ammo.xml
@@ -4,6 +4,7 @@
   <!--=============== Ammo resources ====================-->
 
   <ThingDef ParentName="ResourceBase">
+	<thingClass>CombatExtended.AmmoThing</thingClass>
     <defName>Prometheum</defName>
     <label>prometheum</label>
     <description>Military-grade incendiary agent, ignites on contact with oxygen. The raw resource is used to craft incendiary ammo of all kinds.</description>
@@ -24,9 +25,20 @@
     <thingCategories>
       <li>ResourcesRaw</li>
     </thingCategories>
+    <tickerType>Normal</tickerType>
+    <comps>
+      <li Class="CombatExtended.CompProperties_ExplosiveCE">
+		<explosionDamage>2</explosionDamage>
+        <explosionDamageDef>PrometheumFlame</explosionDamageDef>
+        <explosionRadius>2.6</explosionRadius>
+		<preExplosionSpawnThingDef>FilthPrometheum</preExplosionSpawnThingDef>
+		<preExplosionSpawnChance>1</preExplosionSpawnChance>
+      </li>
+    </comps>
   </ThingDef>
 
   <ThingDef ParentName="ResourceBase">
+	<thingClass>CombatExtended.AmmoThing</thingClass>
     <defName>FSX</defName>
     <label>FSX</label>
     <description>High-explosive chemical extracted from Boomalope sacks, it is used in a variety of industrial and military applications.</description>
@@ -47,6 +59,14 @@
     <thingCategories>
       <li>ResourcesRaw</li>
     </thingCategories>
+    <tickerType>Normal</tickerType>
+    <comps>
+      <li Class="CombatExtended.CompProperties_ExplosiveCE">
+		<explosionDamage>60</explosionDamage>
+        <explosionDamageDef>Bomb</explosionDamageDef>
+        <explosionRadius>3.5</explosionRadius>
+      </li>
+    </comps>
   </ThingDef>
 
 </Defs>

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -61,7 +61,7 @@ namespace CombatExtended
                 {
                     numToCookOff += Mathf.RoundToInt(def.stackLimit * ((float)dinfo.Amount / HitPoints) * (def.smallVolume ? Rand.Range(1f, 2f) : Rand.Range(0.0f, 1f)));
                 }
-                else TryDetonate(Mathf.Lerp(1, Mathf.Min(5, stackCount), stackCount / def.stackLimit));
+                else TryDetonate(Mathf.Min(75, stackCount));
             }
         }
 
@@ -92,12 +92,12 @@ namespace CombatExtended
             }
         }
 
-        private bool TryDetonate(float scale = 1)
+        private bool TryDetonate(float amount = 1)
         {
             CompExplosiveCE comp = this.TryGetComp<CompExplosiveCE>();
             if (comp != null)
             {
-            	if(Rand.Chance(Mathf.Clamp01(0.75f - Mathf.Pow(HitPoints / MaxHitPoints, 2)))) comp.Explode(this, Position.ToVector3Shifted(), Map, scale);
+            	if(Rand.Chance(Mathf.Clamp01(0.75f - Mathf.Pow(HitPoints / MaxHitPoints, 2)))) comp.Explode(this, Position.ToVector3Shifted(), Map, Mathf.Pow(amount, 0.333f));
                 return true;
             }
             return false;

--- a/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
+++ b/Source/CombatExtended/CombatExtended/Things/AmmoThing.cs
@@ -105,7 +105,7 @@ namespace CombatExtended
 
         private bool TryLaunchCookOffProjectile()
         {
-            if (AmmoDef.cookOffProjectile == null) return false;
+            if (AmmoDef == null || AmmoDef.cookOffProjectile == null) return false;
 
             // Spawn projectile if enabled
             if (!Controller.settings.RealisticCookOff)


### PR DESCRIPTION
- Flamethrower fuels Napalm and Prometheum now explode when damaged.
Both soak Prometheum. The napalm does slightly less damage and spreads
fuel puddles rather than prometheum ones.

- Prometheum explodes in 2.6 radius, spawning prometheum filth. The low
damage ensures that the whole stack can slowly cook off rather than
everything exploding at once. This should be balanced better.

- FSX explodes at once with 60 damage, Bomb in radius 3.5 (comparable to
frag grenades).

- To allow for this, TryLaunchCookOffProjectile now null-checks for
AmmoDef existing (which it doesn't on FSX and Prometheum).

- Cubic root of stackCount used for AmmoThing Detonate explosion scale