### PR TITLE
Remove prometheum hediff from napalm

### DIFF
--- a/Defs/Ammo/Flamethrower.xml
+++ b/Defs/Ammo/Flamethrower.xml
@@ -53,7 +53,7 @@
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<explosionDamage>2</explosionDamage>
-        <explosionDamageDef>PrometheumFlame</explosionDamageDef>
+        <explosionDamageDef>Burn</explosionDamageDef>
         <explosionRadius>1</explosionRadius>
 		<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 		<preExplosionSpawnChance>1</preExplosionSpawnChance>

--- a/Defs/Ammo/Flamethrower.xml
+++ b/Defs/Ammo/Flamethrower.xml
@@ -53,7 +53,7 @@
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<explosionDamage>2</explosionDamage>
-        <explosionDamageDef>Burn</explosionDamageDef>
+        <explosionDamageDef>Flame</explosionDamageDef>
         <explosionRadius>1</explosionRadius>
 		<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 		<preExplosionSpawnChance>1</preExplosionSpawnChance>


### PR DESCRIPTION
Uses the standard ~Burn~ Flame def instead, as napalm is crafted with good ol' chemfuel.