### PR TITLE
Fixed tradeable rounds, destroyOnDrop=false for some ammo

### DIFF
--- a/Defs/Ammo/Advanced/12x64mmCharged.xml
+++ b/Defs/Ammo/Advanced/12x64mmCharged.xml
@@ -30,8 +30,9 @@
       <li>Ammo12x64mmCharged</li>
     </thingCategories>
     <stackLimit>200</stackLimit>
-    <tradeability>Sellable</tradeability>
-    <destroyOnDrop>False</destroyOnDrop>
+    <tradeTags>
+      <li>CE_AutoEnableTrade_Sellable</li>
+    </tradeTags>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="12x64mmChargedBase">

--- a/Defs/Ammo/Advanced/5x35mmCharged.xml
+++ b/Defs/Ammo/Advanced/5x35mmCharged.xml
@@ -29,8 +29,9 @@
     <thingCategories>
       <li>Ammo5x35mmCharged</li>
     </thingCategories>
-    <tradeability>Sellable</tradeability>
-    <destroyOnDrop>False</destroyOnDrop>
+    <tradeTags>
+      <li>CE_AutoEnableTrade_Sellable</li>
+    </tradeTags>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="5x35mmChargedBase">

--- a/Defs/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Defs/Ammo/Advanced/80x256mmFuelCell.xml
@@ -30,8 +30,9 @@
       <li>Ammo80x256mmFuelCell</li>
     </thingCategories>
     <stackLimit>25</stackLimit>
-    <tradeability>Sellable</tradeability>
-    <destroyOnDrop>False</destroyOnDrop>
+    <tradeTags>
+      <li>CE_AutoEnableTrade_Sellable</li>
+    </tradeTags>
   </ThingDef>
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="80x256mmFuelBase">

--- a/Defs/Ammo/Shell/81mmMortar.xml
+++ b/Defs/Ammo/Shell/81mmMortar.xml
@@ -168,8 +168,9 @@
     <thingSetMakerTags>
       <li>RewardSpecial</li>
     </thingSetMakerTags>
-    <tradeability>Sellable</tradeability>
-    <destroyOnDrop>False</destroyOnDrop>
+    <tradeTags>
+      <li>CE_AutoEnableTrade_Sellable</li>
+    </tradeTags>
     <ammoClass>Antigrain</ammoClass>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">

--- a/Defs/Ammo/Shell/90mmCannon.xml
+++ b/Defs/Ammo/Shell/90mmCannon.xml
@@ -196,7 +196,7 @@
   
 	<!-- ==================== Recipes ========================== -->
 
-  <RecipeDef ParentName="GrenadeRecipeBase">
+  <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_90mmCannonShell_HEAT</defName>
     <label>make 90mm HEAT cannon shells x5</label>
     <description>Craft 5 90mm HEAT cannon shells.</description>
@@ -239,7 +239,7 @@
     </products>
   </RecipeDef>
 
-  <RecipeDef ParentName="GrenadeRecipeBase">
+  <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_90mmCannonShell_HE</defName>
     <label>make 90mm HE cannon shells x5</label>
     <description>Craft 5 90mm HE cannon shells.</description>
@@ -282,7 +282,7 @@
     </products>
   </RecipeDef>
 
-  <RecipeDef ParentName="GrenadeRecipeBase">
+  <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_90mmCannonShell_EMP</defName>
     <label>make 90mm EMP cannon shells x5</label>
     <description>Craft 5 90mm EMP cannon shells.</description>

--- a/Source/CombatExtended/CombatExtended/AmmoInjector.cs
+++ b/Source/CombatExtended/CombatExtended/AmmoInjector.cs
@@ -121,9 +121,30 @@ namespace CombatExtended
                 ammoDef.AddDescriptionParts();
 
                 // Toggle trading
-                if (ammoDef.tradeTags.Contains(enableTradeTag))
+                var tradingTags = ammoDef.tradeTags.Where(t => t.StartsWith(enableTradeTag));
+                if (tradingTags.Any())
                 {
-                    ammoDef.tradeability = enabled ? Tradeability.All : Tradeability.None;
+                    var curTag = tradingTags.First();
+
+                    if (curTag == enableTradeTag)
+                    {
+                        ammoDef.tradeability = enabled ? Tradeability.All : Tradeability.None;
+                    }
+                    else
+                    {
+                        if (curTag.Length <= enableTradeTag.Length + 1)
+                        {
+                            Log.Error("CE :: AmmoInjector trying to inject " + ammoDef.ToString() + " but " + curTag + " is not a valid trading tag, valid formats are: " + enableTradeTag + " and " + enableTradeTag + "_levelOfTradeability");
+                        }
+                        else
+                        {
+                            var tradeabilityName = curTag.Remove(0, enableTradeTag.Length + 1);
+
+                            ammoDef.tradeability = enabled
+                                ? (Tradeability)Enum.Parse(typeof(Tradeability), tradeabilityName, true)
+                                : Tradeability.None;
+                        }
+                    }
                 }
 
                 // Toggle craftability


### PR DESCRIPTION
- Mechanoid ammo had tradeability = Sellable, which gave warnings. Someone removed the warnings by setting destroyOnDrop=false, but this meant the ammo still existed in the debug menu when the ammo system was off (and could still be found in say mission rewards).

- A new part was written in the AmmoInjector and new tradeTags were allowed so tradeability = Sellable is set when ammo is on, but it's set to None when ammo is off, fixing the issue.

- 90mm Cannon had an incorrect crafting base (GrenadeRecipeBase) which meant the crafting recipe still displayed in the machining table even with ammo turned off.