### PR TITLE
Flamethrower ammo tweaks

### DIFF
--- a/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Advanced.xml
+++ b/Defs/Ammo/AmmoCategoryDefs/AmmoCategories_Advanced.xml
@@ -26,6 +26,18 @@
     <label>incendiary</label>
     <description>Filled with incendiary agent that ignites after impact.</description>
   </CombatExtended.AmmoCategoryDef>
+  
+  <CombatExtended.AmmoCategoryDef>
+    <defName>NapalmFuel</defName>
+    <label>Napalm</label>
+    <description>Highly flammable liquid, burns over time and catches nearby objects on fire.</description>
+  </CombatExtended.AmmoCategoryDef>
+  
+  <CombatExtended.AmmoCategoryDef>
+    <defName>JelliedPrometheumFuel</defName>
+    <label>jellied prometheum</label>
+	<description>Advanced pyrophoric compound in gel-form. Self-ignites on contact with air, sticks to skin and seeps into surfaces, burning even mechanoids.</description>
+  </CombatExtended.AmmoCategoryDef>
 
    <CombatExtended.AmmoCategoryDef>
     <defName>ThermobaricFuel</defName>

--- a/Defs/Ammo/Flamethrower.xml
+++ b/Defs/Ammo/Flamethrower.xml
@@ -49,7 +49,7 @@
     <statBases>
       <MarketValue>0.3</MarketValue>
     </statBases>
-    <ammoClass>IncendiaryFuel</ammoClass>
+    <ammoClass>NapalmFuel</ammoClass>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<explosionDamage>2</explosionDamage>
@@ -71,7 +71,7 @@
     <statBases>
       <MarketValue>0.7</MarketValue>
     </statBases>
-    <ammoClass>IncendiaryFuel</ammoClass>
+    <ammoClass>JelliedPrometheumFuel</ammoClass>
     <comps>
       <li Class="CombatExtended.CompProperties_ExplosiveCE">
 		<explosionDamage>5</explosionDamage>

--- a/Defs/Ammo/Flamethrower.xml
+++ b/Defs/Ammo/Flamethrower.xml
@@ -102,7 +102,7 @@
     <thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
     <label>Napalm stream</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageDef>PrometheumFlame</damageDef>
+      <damageDef>Flame</damageDef>
       <damageAmountBase>3</damageAmountBase>
       <preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
       <preExplosionSpawnChance>0.33</preExplosionSpawnChance>


### PR DESCRIPTION
- Added dedicated categories to flamethrower ammo types
- Removed prometheum effect from napalm projectile