### PR TITLE
Fix JobDriver_TakeFromOther

### DIFF
--- a/Source/CombatExtended/CombatExtended/Jobs/JobDriver_TakeFromOther.cs
+++ b/Source/CombatExtended/CombatExtended/Jobs/JobDriver_TakeFromOther.cs
@@ -99,21 +99,13 @@ namespace CombatExtended
 		protected override IEnumerable<Toil> MakeNewToils()
         {
             this.FailOnDespawnedNullOrForbidden(sourceInd);
-            this.FailOnDestroyedNullOrForbidden(thingInd);
+            this.FailOnDestroyedOrNull(thingInd);
             this.FailOn(DeadTakePawn);
             // We could set a slightly more sane value here which would prevent a hoard of pawns moving from pack animal to pack animal...
             // Also can enforce limits via JobGiver keeping track of how many things it's given away from each pawn, it's a small case though...
             yield return Toils_Reserve.Reserve(sourceInd, int.MaxValue, 0, null);
             yield return Toils_Goto.GotoThing(sourceInd, PathEndMode.Touch);
             yield return Toils_General.Wait(10);
-
-            if (targetItem is AmmoThing)
-            {
-                //For ammo items, this job is flagged with JobCondition.Incompletable, for unknown reasons.
-                //Removing the fail conditions allows the job to be carried out successfully, so the flag is likely being added by mistake at some point.
-                this.globalFailConditions.Clear();
-                //TODO : Find the root cause for ammo getting set as Incompletable
-            }
 
             yield return new Toil
             {


### PR DESCRIPTION
This is a correction of commit 2e3c08c that addresses #713, having now identified the root cause of the issue and implemented a better fix.

Turns out items maintain their forbid state while inside pack animals, and were causing the TakeFromOther job to fail repeatedly when a pawn wants to take a forbidden item from it. The options for fixing were to either not do forbid validation (same as UnloadInventory), or to add a check before the job is started. I opted for the former, as unloading already unforbids the items anyway as the pawns start hauling them, so might as well let colonists have a go at topping up their loadouts.