### PR TITLE
Loadout and wind fixes

### DIFF
--- a/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
+++ b/Source/CombatExtended/CombatExtended/Loadouts/Dialog_ManageLoadouts.cs
@@ -247,7 +247,7 @@ namespace CombatExtended
                         delegate
                         {
                             if (CurrentLoadout == loadouts[local_i])
-								CurrentLoadout = LoadoutManager.DefaultLoadout;
+                                CurrentLoadout = null;
                             LoadoutManager.RemoveLoadout(loadouts[local_i]);
                         }));
                 }

--- a/Source/CombatExtended/CombatExtended/WeatherTracker.cs
+++ b/Source/CombatExtended/CombatExtended/WeatherTracker.cs
@@ -30,7 +30,7 @@ namespace CombatExtended
         public float WindStrength => _windStrength * map.weatherManager.CurWindSpeedFactor;
         public Vector3 WindDirection => Vector3Utility.FromAngleFlat(_windDirection);
 
-        private int BeaufortScale => Mathf.RoundToInt(_windStrength);
+        private int BeaufortScale => Mathf.RoundToInt(WindStrength);
 
         private string WindStrengthText => ("CE_Wind_Beaufort" + BeaufortScale).Translate();
 


### PR DESCRIPTION
- Fix for loadout window as reported in #773. Deleting the currently selected loadout now resets the window to the 'No loadout selected' state, instead of allowing unintended selection of the default 'Nothing' layout.
- Fixed the Beaufort scale property, it was using the internal _windStrength property rather than WindStrength, so it was ignoring the weather's wind modifier.