### PR TITLE
Smoke null region check

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/Smoke.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Smoke.cs
@@ -28,7 +28,9 @@ namespace CombatExtended
 
             // Don't decay if there's lots of smoke around
             var region = Position.GetRegion(Map);
-            var smokeFillage = region.ListerThings.ThingsOfDef(CE_ThingDefOf.Gas_BlackSmoke).Count / region.CellCount;
+            var smokeFillage = region != null
+                ? region.ListerThings.ThingsOfDef(CE_ThingDefOf.Gas_BlackSmoke).Count / region.CellCount
+                : 0;
             if (Rand.Chance(smokeFillage * 2))
                 destroyTick++;
 


### PR DESCRIPTION
Got the error below after loading a save where half my colony is burning down. It appears a small percentage of smoke objects ended up somewhere with a null region, so they throw exceptions on every tick. PR sets the smoke fillage to 0 when no region is given, so smoke will continue decaying without errors until it despawns.

```
Exception ticking Gas_BlackSmoke479726 (at (226, 0, 210)): System.NullReferenceException: Object reference not set to an instance of an object
  at CombatExtended.Smoke.Tick () [0x00000] in <filename unknown>:0 
  at Verse.TickList.Tick () [0x00000] in <filename unknown>:0 
Verse.Log:Error(String, Boolean)
Verse.TickList:Tick()
Verse.TickManager:DoSingleTick()
Verse.TickManager:TickManagerUpdate()
Verse.Game:UpdatePlay()
Verse.Root_Play:Update()
```