### PR TITLE
Flammability info fixes

### DIFF
--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Flammability.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Flammability.cs
@@ -63,7 +63,7 @@ namespace CombatExtended
             var stringBuilder = new StringBuilder();
             stringBuilder.Append(explanation);
 
-            if ((req.Thing is Plant plant))
+            if (req.Thing is Plant plant)
             {
                 stringBuilder.AppendLine();
                 stringBuilder.AppendLine();
@@ -71,10 +71,10 @@ namespace CombatExtended
                     $"{"CE_StatsReport_FlammabilityPrecipitation".Translate().Trim()}: {GetPrecipitationFactorFor(plant).ToStringByStyle(ToStringStyle.PercentZero)}");
             }
 
-            if ((req.Thing is Pawn pawn))
+            if (req.Thing is Pawn pawn && pawn.apparel?.WornApparelCount > 0)
             {
                 GetApparelAdjustFor(pawn, out var apparelFlammability, out var apparelCoverage);
-                apparelFlammability /= apparelCoverage != 0f ? apparelCoverage : 1f;
+                apparelFlammability /= apparelCoverage;
 
                 stringBuilder.AppendLine();
                 stringBuilder.AppendLine();

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Flammability.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_Flammability.cs
@@ -30,8 +30,8 @@ namespace CombatExtended
             apparelCoverage = 0f;
             foreach (var part in pawn.RaceProps.body.AllParts)
             {
-                var apparels = pawn.apparel.WornApparel.FindAll(a => a.def.apparel.CoversBodyPart(part));
-                if (!apparels.Any())
+                var apparels = pawn.apparel?.WornApparel.FindAll(a => a.def.apparel.CoversBodyPart(part));
+                if (apparels == null || !apparels.Any())
                     continue;
 
                 apparels.SortBy(a => a.GetStatValue(StatDefOf.Flammability));
@@ -74,7 +74,7 @@ namespace CombatExtended
             if ((req.Thing is Pawn pawn))
             {
                 GetApparelAdjustFor(pawn, out var apparelFlammability, out var apparelCoverage);
-                apparelFlammability /= apparelCoverage;
+                apparelFlammability /= apparelCoverage != 0f ? apparelCoverage : 1f;
 
                 stringBuilder.AppendLine();
                 stringBuilder.AppendLine();


### PR DESCRIPTION
- Fixed error in animal info window due to null apparel
- Apparel flammability was showing as int.MinValue for pawns with zero coverage, added check on division.