### PR TITLE
Smoke null region check

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/Smoke.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Smoke.cs
@@ -32,8 +32,8 @@ namespace CombatExtended
 
             // Don't decay if there's lots of smoke around
             var region = Position.GetRegion(Map);
-            var smokeFillage = region.ListerThings.ThingsOfDef(CE_ThingDefOf.Gas_BlackSmoke).Count / region.CellCount;
-            if (!Rand.Chance(smokeFillage * 2))
+            var smokeFillage = region?.ListerThings.ThingsOfDef(CE_ThingDefOf.Gas_BlackSmoke).Count / region?.CellCount ?? 0;
+            if (region != null && !Rand.Chance(smokeFillage * 2))
                 destroyTick++;
 
             if (_ticksUntilMove > 0)


### PR DESCRIPTION
Fixes an error that sometimes occurs with large fires, where some of the smoke particles have a null region.

```
Exception ticking Gas_BlackSmoke479726 (at (226, 0, 210)): System.NullReferenceException: Object reference not set to an instance of an object
  at CombatExtended.Smoke.Tick () [0x00000] in <filename unknown>:0 
  at Verse.TickList.Tick () [0x00000] in <filename unknown>:0 
Verse.Log:Error(String, Boolean)
Verse.TickList:Tick()
Verse.TickManager:DoSingleTick()
Verse.TickManager:TickManagerUpdate()
Verse.Game:UpdatePlay()
Verse.Root_Play:Update()
```