### PR TITLE
Typographical correction.

### DIFF
--- a/Defs/Ammo/Advanced/6x24mmCharged.xml
+++ b/Defs/Ammo/Advanced/6x24mmCharged.xml
@@ -101,9 +101,8 @@
           <amount>8</amount>
         </li>
       </secondaryDamage>
-      <armorPenetrationBase>0.65</armorPenetrationBase>
       <armorPenetrationRHA>9</armorPenetrationRHA>
-      <armorPenetrationKPA>256000</armorPenetrationKPA>
+      <armorPenetrationKPA>25600</armorPenetrationKPA>
     </projectile>
   </ThingDef>
 
@@ -118,9 +117,8 @@
           <amount>3</amount>
         </li>
       </secondaryDamage>
-      <armorPenetrationBase>0.8</armorPenetrationBase>
       <armorPenetrationRHA>18</armorPenetrationRHA>
-      <armorPenetrationKPA>256000</armorPenetrationKPA>
+      <armorPenetrationKPA>25600</armorPenetrationKPA>
     </projectile>
   </ThingDef>
 
@@ -135,9 +133,8 @@
           <amount>6</amount>
         </li>
       </secondaryDamage>
-      <armorPenetrationBase>0.65</armorPenetrationBase>
       <armorPenetrationRHA>9</armorPenetrationRHA>
-      <armorPenetrationKPA>256000</armorPenetrationKPA>
+      <armorPenetrationKPA>25600</armorPenetrationKPA>
     </projectile>
   </ThingDef>
 


### PR DESCRIPTION
Removed legacy armor penetration tags for cleanliness, and removed an extra zero that was in armorPenetrationKPA