### PR TITLE
Melee and armor fixes

### DIFF
--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -42,7 +42,11 @@ namespace CombatExtended
             armorDeflected = false;
             armorReduced = false;
 
-            if (originalDinfo.Def.armorCategory == null) return originalDinfo;
+            if (originalDinfo.Def.armorCategory == null
+                || (!(originalDinfo.Weapon?.projectile is ProjectilePropertiesCE projectile) && Verb_MeleeAttackCE.LastAttackVerb == null))
+            {
+                return originalDinfo;
+            }
 
             var dinfo = new DamageInfo(originalDinfo);
             var dmgAmount = dinfo.Amount;
@@ -285,14 +289,7 @@ namespace CombatExtended
             }
             else
             {
-                if (Verb_MeleeAttackCE.LastAttackVerb == null)
-                {
-                    penAmount = 999999;
-                }
-                else
-                {
-                    penAmount = Verb_MeleeAttackCE.LastAttackVerb.ArmorPenetrationKPA;
-                }
+                penAmount = Verb_MeleeAttackCE.LastAttackVerb.ArmorPenetrationKPA;
             }
 
             var force = penAmount * 10;

--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamage.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeDamage.cs
@@ -61,7 +61,7 @@ namespace CombatExtended
             Pawn pawnHolder = (req.Thing.ParentHolder is Pawn_EquipmentTracker) ? ((Pawn_EquipmentTracker)req.Thing.ParentHolder).pawn : null;
             float skilledDamageVariationMin = GetDamageVariationMin(pawnHolder);
             float skilledDamageVariationMax = GetDamageVariationMax(pawnHolder);
-            int meleeSkillLevel = pawnHolder?.skills.GetSkill(SkillDefOf.Melee).Level ?? -1;
+            int meleeSkillLevel = pawnHolder?.skills?.GetSkill(SkillDefOf.Melee)?.Level ?? -1;
 
             var tools = (req.Def as ThingDef)?.tools;
 


### PR DESCRIPTION
- #810 updated the statworker to allow min/max damage queries from pawns that have a null skills field, but I forgot to add an equivalent check to the stat's info window.
- Injuries not caused by a projectile or melee verb now skip armor modifiers, as these types of injuries (surgery failures, wounds added on spawn) aren't meant to roll against armor.