### PR TITLE
Final Ammo 1.6

### DIFF
--- a/Defs/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Defs/Ammo/Grenade/30x29mmGrenade.xml
@@ -25,7 +25,7 @@
     <description>Relatively small, low velocity grenade for use in grenade launchers.</description>
     <statBases>
       <Mass>0.36</Mass>
-      <Bulk>0.38</Bulk>
+      <Bulk>0.28</Bulk>
     </statBases>
     <tradeTags>
       <li>CE_AutoEnableTrade</li>

--- a/Defs/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Defs/Ammo/Grenade/40x46mmGrenade.xml
@@ -25,7 +25,7 @@
     <description>Low velocity grenade fired from handheld grenade launchers.</description>
     <statBases>
       <Mass>0.23</Mass>
-      <Bulk>0.5</Bulk>
+      <Bulk>0.38</Bulk>
     </statBases>
     <tradeTags>
       <li>CE_AutoEnableTrade</li>

--- a/Defs/Ammo/Rifle/303British.xml
+++ b/Defs/Ammo/Rifle/303British.xml
@@ -98,7 +98,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="303BritishBase">
     <defName>Ammo_303British_HE</defName>
-    <label>.303 British cartridge (AP-HE)</label>
+    <label>.303 British cartridge (HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -187,7 +187,7 @@
 	  
 	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base303BritishBullet">
 		<defName>Bullet_303British_HE</defName>
-		<label>.303 British bullet (AP-HE)</label>
+		<label>.303 British bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>19</damageAmountBase>
 		  <armorPenetrationRHA>6</armorPenetrationRHA>
@@ -295,8 +295,8 @@
 
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_303British_Incendiary</defName>
-    <label>make .303 British (AP-I) cartridge x200</label>
-    <description>Craft 200 .303 British (AP-I) cartridges.</description>
+    <label>make .303 British (AP-I) cartridge x500</label>
+    <description>Craft 500 .303 British (AP-I) cartridges.</description>
     <jobString>Making .303 British (AP-I) cartridges.</jobString>
     <ingredients>
       <li>
@@ -330,8 +330,8 @@
   
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_303British_HE</defName>
-    <label>make .303 British (AP-HE) cartridge x200</label>
-    <description>Craft 200 .303 British (HE) cartridges.</description>
+    <label>make .303 British (HE) cartridge x500</label>
+    <description>Craft 500 .303 British (HE) cartridges.</description>
     <jobString>Making .303 British (HE) cartridges.</jobString>
     <ingredients>
       <li>
@@ -365,8 +365,8 @@
   
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_303British_Sabot</defName>
-    <label>make .303 British (Sabot) cartridge x200</label>
-    <description>Craft 200 .303 British (Sabot) cartridges.</description>
+    <label>make .303 British (Sabot) cartridge x500</label>
+    <description>Craft 500 .303 British (Sabot) cartridges.</description>
     <jobString>Making .303 British (Sabot) cartridges.</jobString>
     <ingredients>
       <li>

--- a/Defs/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/545x39mmSoviet.xml
@@ -98,7 +98,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="545x39mmSovietBase">
     <defName>Ammo_545x39mmSoviet_HE</defName>
-    <label>5.45x39mm Soviet cartridge (AP-HE)</label>
+    <label>5.45x39mm Soviet cartridge (HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -187,7 +187,7 @@
 	  
 	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base545x39mmSovietBullet">
 		<defName>Bullet_545x39mmSoviet_HE</defName>
-		<label>5.45mm Soviet bullet (AP-HE)</label>
+		<label>5.45mm Soviet bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>13</damageAmountBase>
 		  <armorPenetrationRHA>6</armorPenetrationRHA>
@@ -293,4 +293,118 @@
 		<workAmount>1200</workAmount>
 	</RecipeDef>
 
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_545x39mmSoviet_Incendiary</defName>
+    <label>make 5.45x39mm Soviet (AP-I) cartridge x500</label>
+    <description>Craft 500 5.45x39mm Soviet (AP-I) cartridges.</description>
+    <jobString>Making 5.45x39mm Soviet (AP-I) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>12</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Prometheum</li>
+          </thingDefs>
+        </filter>
+        <count>1</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Prometheum</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_545x39mmSoviet_Incendiary>500</Ammo_545x39mmSoviet_Incendiary>
+    </products>
+    <workAmount>1600</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_545x39mmSoviet_HE</defName>
+    <label>make 5.45x39mm Soviet (HE) cartridge x500</label>
+    <description>Craft 500 5.45x39mm Soviet (HE) cartridges.</description>
+    <jobString>Making 5.45x39mm Soviet (HE) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>12</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>FSX</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>FSX</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_545x39mmSoviet_HE>500</Ammo_545x39mmSoviet_HE>
+    </products>
+    <workAmount>2800</workAmount>
+  </RecipeDef>
+  
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_545x39mmSoviet_Sabot</defName>
+    <label>make 5.45x39mm Soviet (Sabot) cartridge x500</label>
+    <description>Craft 500 5.45x39mm Soviet (Sabot) cartridges.</description>
+    <jobString>Making 5.45x39mm Soviet (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>8</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>2</count>
+      </li>		  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Steel</li>
+        <li>Uranium</li>
+        <li>Chemfuel</li>		
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_545x39mmSoviet_Sabot>500</Ammo_545x39mmSoviet_Sabot>
+    </products>
+    <workAmount>2000</workAmount>
+  </RecipeDef>
+  
 </Defs>

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -296,7 +296,7 @@
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_556x45mmNATO_Incendiary</defName>
     <label>make 5.56x45mm NATO (AP-I) cartridge x500</label>
-    <description>Craft 5005.56x45mm NATO (AP-I) cartridges.</description>
+    <description>Craft 500 5.56x45mm NATO (AP-I) cartridges.</description>
     <jobString>Making 5.56x45mm NATO (AP-I) cartridges.</jobString>
     <ingredients>
       <li>
@@ -331,7 +331,7 @@
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_556x45mmNATO_HE</defName>
     <label>make 5.56x45mm NATO (HE) cartridge x500</label>
-    <description>Craft 5005.56x45mm NATO (HE) cartridges.</description>
+    <description>Craft 500 5.56x45mm NATO (HE) cartridges.</description>
     <jobString>Making 5.56x45mm NATO (HE) cartridges.</jobString>
     <ingredients>
       <li>
@@ -366,7 +366,7 @@
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_556x45mmNATO_Sabot</defName>
     <label>make 5.56x45mm NATO (Sabot) cartridge x500</label>
-    <description>Craft 5005.56x45mm NATO (Sabot) cartridges.</description>
+    <description>Craft 500 5.56x45mm NATO (Sabot) cartridges.</description>
     <jobString>Making 5.56x45mm NATO (Sabot) cartridges.</jobString>
     <ingredients>
       <li>

--- a/Defs/Ammo/Rifle/556x45mmNATO.xml
+++ b/Defs/Ammo/Rifle/556x45mmNATO.xml
@@ -98,7 +98,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">
     <defName>Ammo_556x45mmNATO_HE</defName>
-    <label>5.56x45mm NATO cartridge (AP-HE)</label>
+    <label>5.56x45mm NATO cartridge (HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -187,7 +187,7 @@
 	  
 	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base556x45mmNATOBullet">
 		<defName>Bullet_556x45mmNATO_HE</defName>
-		<label>5.56mm NATO bullet (AP-HE)</label>
+		<label>5.56mm NATO bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>14</damageAmountBase>
 		  <armorPenetrationRHA>4</armorPenetrationRHA>
@@ -295,8 +295,8 @@
 
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_556x45mmNATO_Incendiary</defName>
-    <label>make 5.56x45mm NATO (AP-I) cartridge x200</label>
-    <description>Craft 200 5.56x45mm NATO (AP-I) cartridges.</description>
+    <label>make 5.56x45mm NATO (AP-I) cartridge x500</label>
+    <description>Craft 5005.56x45mm NATO (AP-I) cartridges.</description>
     <jobString>Making 5.56x45mm NATO (AP-I) cartridges.</jobString>
     <ingredients>
       <li>
@@ -330,8 +330,8 @@
   
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_556x45mmNATO_HE</defName>
-    <label>make 5.56x45mm NATO (AP-HE) cartridge x200</label>
-    <description>Craft 200 5.56x45mm NATO (HE) cartridges.</description>
+    <label>make 5.56x45mm NATO (HE) cartridge x500</label>
+    <description>Craft 5005.56x45mm NATO (HE) cartridges.</description>
     <jobString>Making 5.56x45mm NATO (HE) cartridges.</jobString>
     <ingredients>
       <li>
@@ -365,8 +365,8 @@
   
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_556x45mmNATO_Sabot</defName>
-    <label>make 5.56x45mm NATO (Sabot) cartridge x200</label>
-    <description>Craft 200 5.56x45mm NATO (Sabot) cartridges.</description>
+    <label>make 5.56x45mm NATO (Sabot) cartridge x500</label>
+    <description>Craft 5005.56x45mm NATO (Sabot) cartridges.</description>
     <jobString>Making 5.56x45mm NATO (Sabot) cartridges.</jobString>
     <ingredients>
       <li>

--- a/Defs/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/762x39mmSoviet.xml
@@ -98,7 +98,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="762x39mmSovietBase">
     <defName>Ammo_762x39mmSoviet_HE</defName>
-    <label>7.62x39mm Soviet cartridge (AP-HE)</label>
+    <label>7.62x39mm Soviet cartridge (HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -199,7 +199,7 @@
 	  
 	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x39mmSovietBullet">
 		<defName>Bullet_762x39mmSoviet_HE</defName>
-		<label>7.62mm Soviet bullet (AP-HE)</label>
+		<label>7.62mm Soviet bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>17</damageAmountBase>
 		  <armorPenetrationRHA>7</armorPenetrationRHA>
@@ -307,8 +307,8 @@
 
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_762x39mmSoviet_Incendiary</defName>
-    <label>make 7.62x39mm Soviet (AP-I) cartridge x200</label>
-    <description>Craft 200 7.62x39mm Soviet (AP-I) cartridges.</description>
+    <label>make 7.62x39mm Soviet (AP-I) cartridge x500</label>
+    <description>Craft 500 7.62x39mm Soviet (AP-I) cartridges.</description>
     <jobString>Making 7.62x39mm Soviet (AP-I) cartridges.</jobString>
     <ingredients>
       <li>
@@ -342,8 +342,8 @@
   
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_762x39mmSoviet_HE</defName>
-    <label>make 7.62x39mm Soviet (AP-HE) cartridge x200</label>
-    <description>Craft 200 7.62x39mm Soviet (HE) cartridges.</description>
+    <label>make 7.62x39mm Soviet (HE) cartridge x500</label>
+    <description>Craft 500 7.62x39mm Soviet (HE) cartridges.</description>
     <jobString>Making 7.62x39mm Soviet (HE) cartridges.</jobString>
     <ingredients>
       <li>
@@ -377,8 +377,8 @@
   
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_762x39mmSoviet_Sabot</defName>
-    <label>make 7.62x39mm Soviet (Sabot) cartridge x200</label>
-    <description>Craft 200 7.62x39mm Soviet (Sabot) cartridges.</description>
+    <label>make 7.62x39mm Soviet (Sabot) cartridge x500</label>
+    <description>Craft 500 7.62x39mm Soviet (Sabot) cartridges.</description>
     <jobString>Making 7.62x39mm Soviet (Sabot) cartridges.</jobString>
     <ingredients>
       <li>

--- a/Defs/Ammo/Rifle/762x51mmNATO.xml
+++ b/Defs/Ammo/Rifle/762x51mmNATO.xml
@@ -98,7 +98,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">
     <defName>Ammo_762x51mmNATO_HE</defName>
-    <label>7.62x51mm NATO cartridge (AP-HE)</label>
+    <label>7.62x51mm NATO cartridge (HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -186,7 +186,7 @@
 	  
 	  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x51mmNATOBullet">
 		<defName>Bullet_762x51mmNATO_HE</defName>
-		<label>7.62mm NATO bullet (AP-HE)</label>
+		<label>7.62mm NATO bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 		  <damageAmountBase>20</damageAmountBase>
 		  <armorPenetrationRHA>6</armorPenetrationRHA>
@@ -294,8 +294,8 @@
 
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_762x51mmNATO_Incendiary</defName>
-    <label>make 7.62x51mm NATO (AP-I) cartridge x200</label>
-    <description>Craft 200 7.62x51mm NATO (AP-I) cartridges.</description>
+    <label>make 7.62x51mm NATO (AP-I) cartridge x500</label>
+    <description>Craft 500 7.62x51mm NATO (AP-I) cartridges.</description>
     <jobString>Making 7.62x51mm NATO (AP-I) cartridges.</jobString>
     <ingredients>
       <li>
@@ -329,8 +329,8 @@
   
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_762x51mmNATO_HE</defName>
-    <label>make 7.62x51mm NATO (AP-HE) cartridge x200</label>
-    <description>Craft 200 7.62x51mm NATO (HE) cartridges.</description>
+    <label>make 7.62x51mm NATO (HE) cartridge x500</label>
+    <description>Craft 500 7.62x51mm NATO (HE) cartridges.</description>
     <jobString>Making 7.62x51mm NATO (HE) cartridges.</jobString>
     <ingredients>
       <li>
@@ -364,8 +364,8 @@
   
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_762x51mmNATO_Sabot</defName>
-    <label>make 7.62x51mm NATO (Sabot) cartridge x200</label>
-    <description>Craft 200 7.62x51mm NATO (Sabot) cartridges.</description>
+    <label>make 7.62x51mm NATO (Sabot) cartridge x500</label>
+    <description>Craft 500 7.62x51mm NATO (Sabot) cartridges.</description>
     <jobString>Making 7.62x51mm NATO (Sabot) cartridges.</jobString>
     <ingredients>
       <li>

--- a/Defs/Ammo/Rifle/762x54mmR.xml
+++ b/Defs/Ammo/Rifle/762x54mmR.xml
@@ -98,7 +98,7 @@
 
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="762x54mmRBase">
     <defName>Ammo_762x54mmR_HE</defName>
-    <label>7.62x54mmR cartridge (AP-HE)</label>
+    <label>7.62x54mmR cartridge (HE)</label>
     <graphicData>
       <texPath>Things/Ammo/Rifle/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -187,7 +187,7 @@
   
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base762x54mmRBullet">
     <defName>Bullet_762x54mmR_HE</defName>
-    <label>7.62mmR bullet (AP-HE)</label>
+    <label>7.62mmR bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>20</damageAmountBase>
       <armorPenetrationRHA>7</armorPenetrationRHA>
@@ -295,8 +295,8 @@
 
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_762x54mmR_Incendiary</defName>
-    <label>make 7.62x54mmR (AP-I) cartridge x200</label>
-    <description>Craft 200 7.62x54mmR (AP-I) cartridges.</description>
+    <label>make 7.62x54mmR (AP-I) cartridge x500</label>
+    <description>Craft 500 7.62x54mmR (AP-I) cartridges.</description>
     <jobString>Making 7.62x54mmR (AP-I) cartridges.</jobString>
     <ingredients>
       <li>
@@ -330,8 +330,8 @@
   
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_762x54mmR_HE</defName>
-    <label>make 7.62x54mmR (AP-HE) cartridge x200</label>
-    <description>Craft 200 7.62x54mmR (HE) cartridges.</description>
+    <label>make 7.62x54mmR (HE) cartridge x500</label>
+    <description>Craft 500 7.62x54mmR (HE) cartridges.</description>
     <jobString>Making 7.62x54mmR (HE) cartridges.</jobString>
     <ingredients>
       <li>
@@ -365,8 +365,8 @@
   
   <RecipeDef ParentName="AmmoRecipeBase">
     <defName>MakeAmmo_762x54mmR_Sabot</defName>
-    <label>make 7.62x54mmR (Sabot) cartridge x200</label>
-    <description>Craft 200 7.62x54mmR (Sabot) cartridges.</description>
+    <label>make 7.62x54mmR (Sabot) cartridge x500</label>
+    <description>Craft 500 7.62x54mmR (Sabot) cartridges.</description>
     <jobString>Making 7.62x54mmR (Sabot) cartridges.</jobString>
     <ingredients>
       <li>


### PR DESCRIPTION
A couple final tweaks/fixes for ammo. Updated the AP-HE labels to HE, changed 30 and 40mm grenade bulk to the current sheet value, added recipes for the 3 new ammo types for 5.45 Soviet which I overlooked, and corrected the ammo quantity in the recipe labels.