### PR TITLE
Misc fixes

### DIFF
--- a/Patches/Core/FactionDefs/Factions_Misc.xml
+++ b/Patches/Core/FactionDefs/Factions_Misc.xml
@@ -24,11 +24,20 @@
       <earliestRaidDays>60</earliestRaidDays>
     </value>
   </Operation>
-
+  
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/FactionDef[defName="Mechanoid"]/pawnGroupMakers/li[1]/options/Mech_Centipede</xpath>
     <value>
       <Mech_Centipede>50</Mech_Centipede>
+    </value>
+  </Operation>
+
+  <!-- ========== Allow mechanoid faction to use ImmediateAttackSmart ========== -->
+  
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/FactionDef[defName="Mechanoid"]/canUseAvoidGrid</xpath>
+    <value>
+      <canUseAvoidGrid>true</canUseAvoidGrid>
     </value>
   </Operation>
 

--- a/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
+++ b/Source/CombatExtended/CombatExtended/ArmorUtilityCE.cs
@@ -43,7 +43,10 @@ namespace CombatExtended
             armorReduced = false;
 
             if (originalDinfo.Def.armorCategory == null
-                || (!(originalDinfo.Weapon?.projectile is ProjectilePropertiesCE projectile) && Verb_MeleeAttackCE.LastAttackVerb == null))
+                || (!(originalDinfo.Weapon?.projectile is ProjectilePropertiesCE projectile)
+                    && Verb_MeleeAttackCE.LastAttackVerb == null
+                    && originalDinfo.Weapon == null
+                    && originalDinfo.Instigator == null))
             {
                 return originalDinfo;
             }
@@ -289,7 +292,16 @@ namespace CombatExtended
             }
             else
             {
-                penAmount = Verb_MeleeAttackCE.LastAttackVerb.ArmorPenetrationKPA;
+                if (Verb_MeleeAttackCE.LastAttackVerb == null)
+                {
+                    //LastAttackVerb is already checked in GetAfterArmorDamage(). Only known case of code arriving here is with the ancient soldiers
+                    //spawned at the start of the game: their wounds are usually applied with Weapon==null and Instigator==null, so they skip CE's armor system,
+                    //but on rare occasions, one of the soldiers gets Bite injuries with with Weapon==null and the instigator set as *himself*.
+                    //Warning message below to identify any other situations where this might be happening. -LX7
+                    Log.Warning($"[CE] Deflection for Instigator:{dinfo.Instigator} Target:{dinfo.IntendedTarget} DamageDef:{dinfo.Def} Weapon:{dinfo.Weapon} has null verb, overriding AP.");
+                    
+                }
+                penAmount = Verb_MeleeAttackCE.LastAttackVerb?.ArmorPenetrationKPA ?? 999999;
             }
 
             var force = penAmount * 10;

--- a/Source/CombatExtended/CombatExtended/MassBulkUtility.cs
+++ b/Source/CombatExtended/CombatExtended/MassBulkUtility.cs
@@ -25,10 +25,10 @@ namespace CombatExtended
 
         public static float MoveSpeedFactor(float weight, float weightCapacity)
         {
-			float t = weight / weightCapacity;
-			if (float.IsNaN(t)) t = 1f;
-			return Mathf.Lerp(1f, 0.75f, t);
-		}
+            float t = weight / weightCapacity;
+            if (float.IsNaN(t)) t = 1f;
+            return Mathf.Lerp(1f, 0.75f, t);
+        }
 
         public static float WorkSpeedFactor(float bulk, float bulkCapacity)
         {
@@ -38,7 +38,14 @@ namespace CombatExtended
         public static float EncumberPenalty(float weight, float weightCapacity)
         {
             if (weight > weightCapacity)
-                return weight / weightCapacity - 1;
+            {
+                float weightPercent = weight / weightCapacity;
+                if (float.IsPositiveInfinity(weightPercent))
+                {
+                    return 1f;
+                }
+                return weightPercent - 1;
+            }
             else
                 return 0f;
         }


### PR DESCRIPTION
- Restored mechanoid raids.
- Updated armor-bypass conditions, as a lot of injuries (explosions, fires, etc) were getting skipped due to having no projectile or melee verb. The addition of Weapon and Instigator checks should cover all damageInfos that occur during gameplay, while still skipping armor evaluation on surgeries and on-spawn injuries.
- Fixed a display issue where encumbrance penalty for a pawn with 0% Moving was shown as -2147483647%, due to a divide-by-zero.