### PR TITLE
CompAmmoUser caliber change detection

### DIFF
--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -106,7 +106,7 @@ namespace CombatExtended
                 return UseAmmo ? currentAmmoInt : null;
             }
         }
-        public ThingDef CurAmmoProjectile => Props.ammoSet?.ammoTypes?.FirstOrDefault(x => x.ammo == CurrentAmmo).projectile;
+        public ThingDef CurAmmoProjectile => Props.ammoSet?.ammoTypes?.FirstOrDefault(x => x.ammo == CurrentAmmo)?.projectile ?? parent.def.Verbs.FirstOrDefault().defaultProjectile;
         public CompInventory CompInventory
         {
             get


### PR DESCRIPTION
CompAmmoUser now recovers from invalid state when a weapon's caliber is changed, so previous instances of MAC-10 in the savefile won't have to be deleted.