### PR TITLE
Store mechanoid letter state in savefile

### DIFF
--- a/Source/CombatExtended/CombatExtended/LetterTracker.cs
+++ b/Source/CombatExtended/CombatExtended/LetterTracker.cs
@@ -28,5 +28,11 @@ namespace CombatExtended
                 _sentMechWarning = true;
             }
         }
+
+        public override void ExposeData()
+        {
+            base.ExposeData();
+            Scribe_Values.Look<bool>(ref _sentMechWarning, "sentMechWarning", false, false);
+        }
     }
 }


### PR DESCRIPTION
The mechanoid warning letter is getting sent again every time the player quits to main menu and reloads the save. Putting the variable in the savefile so it only gets sent once per playthrough.