### PR TITLE
Unarmed damage stat as offset

### DIFF
--- a/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Defs/Stats/Stats_Pawns_Combat.xml
@@ -281,22 +281,22 @@
   
   <StatDef>
     <defName>UnarmedDamage</defName>
-    <label>unarmed damage</label>
-    <description>Damage done in unarmed combat.</description>
+    <label>unarmed damage bonus</label>
+    <description>Additional damage done in unarmed combat.</description>
     <category>PawnCombat</category>
     <displayPriorityInCategory>99</displayPriorityInCategory>
-    <defaultBaseValue>1</defaultBaseValue>
+    <defaultBaseValue>0</defaultBaseValue>
     <showOnPawns>true</showOnPawns>
     <minValue>0.0</minValue>
     <maxValue>10.0</maxValue>
-    <toStringStyle>PercentZero</toStringStyle>
-    <skillNeedFactors>
+    <toStringStyle>FloatMaxTwo</toStringStyle>
+    <skillNeedOffsets>
       <li Class="SkillNeed_BaseBonus">
         <skill>Melee</skill>
         <baseValue>0.00</baseValue>
-        <bonusPerLevel>1.00</bonusPerLevel>
+        <bonusPerLevel>0.50</bonusPerLevel>
       </li>
-    </skillNeedFactors>
+    </skillNeedOffsets>
     <capacityFactors>
       <li>
         <capacity>Sight</capacity>

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -217,10 +217,16 @@ namespace CombatExtended
             BodyPartGroupDef bodyPartGroupDef = null;
             HediffDef hediffDef = null;
 
-            var damVariation = EquipmentSource == null
-                ? CasterPawn.GetStatValue(CE_StatDefOf.UnarmedDamage)
-                : Rand.Range(StatWorker_MeleeDamage.GetDamageVariationMin(CasterPawn), StatWorker_MeleeDamage.GetDamageVariationMax(CasterPawn));
-            damAmount *= damVariation;
+            if (EquipmentSource != null)
+            {
+                //melee weapon damage variation
+                damAmount *= Rand.Range(StatWorker_MeleeDamage.GetDamageVariationMin(CasterPawn), StatWorker_MeleeDamage.GetDamageVariationMax(CasterPawn));
+            }
+            else
+            {
+                //unarmed damage bonus offset
+                damAmount += CasterPawn.GetStatValue(CE_StatDefOf.UnarmedDamage);
+            }
 
             if (CasterIsPawn)
             {


### PR DESCRIPTION
So that artificial arms don't get up to longsword-tier damage at high melee skill, the stat now works as an offset instead of multiplier, adding between 0 to 10 damage to the attack.