### PR TITLE
Fix unarmed damage stat being used by non-violent

### DIFF
--- a/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeStats.cs
+++ b/Source/CombatExtended/CombatExtended/StatWorkers/StatWorker_MeleeStats.cs
@@ -12,7 +12,7 @@ namespace CombatExtended
     {
         public override bool IsDisabledFor(Thing thing)
         {
-            return thing?.def?.building?.IsTurret ?? false;
+            return thing?.def?.building?.IsTurret ?? base.IsDisabledFor(thing);
         }
     }
 }

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_MeleeAttackCE.cs
@@ -222,7 +222,7 @@ namespace CombatExtended
                 //melee weapon damage variation
                 damAmount *= Rand.Range(StatWorker_MeleeDamage.GetDamageVariationMin(CasterPawn), StatWorker_MeleeDamage.GetDamageVariationMax(CasterPawn));
             }
-            else
+            else if (!CE_StatDefOf.UnarmedDamage.Worker.IsDisabledFor(CasterPawn))  //ancient soldiers can punch even if non-violent, this prevents the disabled stat from being used
             {
                 //unarmed damage bonus offset
                 damAmount += CasterPawn.GetStatValue(CE_StatDefOf.UnarmedDamage);


### PR DESCRIPTION
Ancient soldiers ignore the non-violent restriction, so they attempt to use the unarmed damage stat and cause console errors.