### PR TITLE
Streamlined arrow bug fix

### DIFF
--- a/Defs/Ammo/Neolithic/Arrows.xml
+++ b/Defs/Ammo/Neolithic/Arrows.xml
@@ -192,7 +192,7 @@
       <armorPenetrationSharp>0.5</armorPenetrationSharp>
       <armorPenetrationBlunt>1.920</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.2</preExplosionSpawnChance>
-      <preExplosionSpawnThingDef>Ammo_GreatArrow_Stone</preExplosionSpawnThingDef>
+      <preExplosionSpawnThingDef>Ammo_Arrow_Stone</preExplosionSpawnThingDef>
     </projectile>
   </ThingDef>
 
@@ -209,7 +209,7 @@
       <armorPenetrationSharp>1.0</armorPenetrationSharp>
       <armorPenetrationBlunt>2.960</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.6</preExplosionSpawnChance>
-      <preExplosionSpawnThingDef>Ammo_GreatArrow_Steel</preExplosionSpawnThingDef>
+      <preExplosionSpawnThingDef>Ammo_Arrow_Steel</preExplosionSpawnThingDef>
     </projectile>
   </ThingDef>
 
@@ -226,7 +226,7 @@
       <armorPenetrationSharp>1.5</armorPenetrationSharp>
       <armorPenetrationBlunt>3.260</armorPenetrationBlunt>
       <preExplosionSpawnChance>0.75</preExplosionSpawnChance>
-      <preExplosionSpawnThingDef>Ammo_GreatArrow_Plasteel</preExplosionSpawnThingDef>
+      <preExplosionSpawnThingDef>Ammo_Arrow_Plasteel</preExplosionSpawnThingDef>
     </projectile>
   </ThingDef>
 


### PR DESCRIPTION
Fixed bug where streamlined <preExplosionSpawnThingDef> was Great Arrows instead of regular ones.