### PR TITLE
Fixed failed GouRIMet PatchOp

### DIFF
--- a/Patches/GouRIMet/Items_GouRIMet.xml
+++ b/Patches/GouRIMet/Items_GouRIMet.xml
@@ -12,7 +12,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="CaramelBalls" or
 				defName="HotCocoa" or
-				defName="HotTea" or
+				defName="HotTea"
 				]/statBases</xpath>
 				<value>
 					<Bulk>0.05</Bulk>


### PR DESCRIPTION
Fixed parse issue that was causing the patch for GouRIMet to fail.