### PR TITLE
Cybernet Melee Stats

### DIFF
--- a/Patches/Cybernet/HediffDefs/Hediffs_CyberNet_BodyParts.xml
+++ b/Patches/Cybernet/HediffDefs/Hediffs_CyberNet_BodyParts.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+        <li>CyberNet</li>
+    </mods>
+	<match Class="PatchOperationSequence">
+		<operations>
+		<!--Base version is comparable to bionic arm-->
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="CNNetworkedArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>1.11</cooldownTime>
+						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="CNAdvancedNetworkedArm"]/comps/li[@Class="HediffCompProperties_VerbGiver"]/tools</xpath>
+			<value>
+				<tools>
+					<li Class="CombatExtended.ToolCE">
+						<label>fist</label>
+						<capacities>
+							<li>Blunt</li>
+						</capacities>
+						<power>7</power>
+						<cooldownTime>0.98</cooldownTime>
+						<armorPenetrationBlunt>2.168</armorPenetrationBlunt>
+					</li>
+				</tools>
+			</value>
+		</li>
+		
+		</operations>
+	</match>
+	</Operation>
+</Patch>
+


### PR DESCRIPTION
Add 1.6 compatible melee stats for the networked arms from Cybernet.

The other functions of the mod don't seem to break in CE.