### PR TITLE
Dinosauria leather stuff and trophy CE1.6

### DIFF
--- a/Patches/Dinosauria/Items_Resource_Dinosauria_Items.xml
+++ b/Patches/Dinosauria/Items_Resource_Dinosauria_Items.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+		
+			<!-- ==== Check for the mod. ==== -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Dinosauria</modName>
+			</li>
+
+			<!-- ====== Triceratops Horn ====== -->
+
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="TriceratopsHorn"]/tools</xpath>
+			</li>
+
+			<li Class="PatchOperationAttributeSet">
+				<xpath>Defs/ThingDef[defName="TriceratopsHorn"]</xpath>
+				<attribute>ParentName</attribute>
+				<value>ResourceBase</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Dinosauria/Items_Resource_Dinosauria_Stuff_Leather.xml
+++ b/Patches/Dinosauria/Items_Resource_Dinosauria_Stuff_Leather.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<!-- ==== Check for the mod. ==== -->
+			<li Class="CombatExtended.PatchOperationFindMod">
+				<modName>Dinosauria</modName>
+			</li>
+
+			<!--========== Basic leathers ============-->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_Raptor" or defName="Leather_DinosaurFuzz" or defName="Leather_DinosaurHide"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<!--========== Thin leathers ============-->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_DinosaurSkin" or defName="Leather_PterosaurSkin"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.03</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_DinosaurSkin" or defName="Leather_PterosaurSkin"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.02</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<!--========== Tough leathers ============-->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_Theropod" or defName="Leather_Sauropod" or defName="Leather_Redhide"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.06</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_Theropod" or defName="Leather_Redhide"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.04</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<!--========== Super leathers ============-->
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_Tyrannosaurus" or defName="Leather_Spinosaurus"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.72</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_Tyrannosaurus" or defName="Leather_Spinosaurus"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.1</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_Bluefuzz"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.7</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_Bluefuzz"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.09</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_ArmoredDino"]/statBases/StuffPower_Armor_Sharp</xpath>
+				<value>
+					<StuffPower_Armor_Sharp>0.75</StuffPower_Armor_Sharp>
+				</value>
+			</li>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="Leather_ArmoredDino"]/statBases/StuffPower_Armor_Blunt</xpath>
+				<value>
+					<StuffPower_Armor_Blunt>0.14</StuffPower_Armor_Blunt>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+</Patch>


### PR DESCRIPTION
- Dino leathers changed for 1.6
- Triceraptor horn is not a weapon now like other animal trophies in CE.