### PR TITLE
Updated Penetration/Damage Ammodefs

### DIFF
--- a/Defs/Ammo/Advanced/12GaugeCharged.xml
+++ b/Defs/Ammo/Advanced/12GaugeCharged.xml
@@ -89,7 +89,7 @@
       <speed>100</speed>
     </projectile>
   </ThingDef>
-
+  <!--500m/s Buckshot/Slug mass-->
   <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base12GaugeChargedBullet">
     <defName>Bullet_12GaugeCharged</defName>
     <label>charge pellet</label>
@@ -102,6 +102,8 @@
         </li>
       </secondaryDamage>
       <armorPenetrationBase>0.35</armorPenetrationBase>
+	  <armorPenetrationSharp>5</armorPenetrationSharp>
+	  <armorPenetrationBlunt>8.72</armorPenetrationBlunt>
       <pelletCount>9</pelletCount>
       <spreadMult>17.8</spreadMult>
     </projectile>
@@ -119,6 +121,8 @@
         </li>
       </secondaryDamage>
       <armorPenetrationBase>0.6</armorPenetrationBase>
+	  <armorPenetrationSharp>7</armorPenetrationSharp>
+	  <armorPenetrationBlunt>70.76</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -134,6 +138,8 @@
         </li>
       </secondaryDamage>
       <armorPenetrationBase>0.4</armorPenetrationBase>
+	  <armorPenetrationSharp>5</armorPenetrationSharp>
+	  <armorPenetrationBlunt>70.76</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Defs/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -54,7 +54,9 @@
 			<casingMoteDefname>Mote_ShotgunShell</casingMoteDefname>
 		</projectile>
 	</ThingDef>
-
+	
+	<!--2mm/560ms/3g-->
+	
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base15x65mmDiffusingChargedBullet">
 		<defName>Bullet_15x65mmDiffusingCharged_Buck</defName>
 		<label>buckshot charged</label>
@@ -72,6 +74,8 @@
         </li>
       </secondaryDamage>
 			<armorPenetrationBase>0.65</armorPenetrationBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>9.4</armorPenetrationBlunt>
 			<spreadMult>17.8</spreadMult>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
+++ b/Defs/Ammo/HighCaliber/12.7x108mmSoviet.xml
@@ -98,8 +98,10 @@
     <defName>Bullet_127x108mm_FMJ</defName>
     <label>12.7x108mm bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>45</damageAmountBase>
+      <damageAmountBase>40</damageAmountBase>
       <armorPenetrationBase>0.90</armorPenetrationBase>
+	  <armorPenetrationSharp>12</armorPenetrationSharp>
+	  <armorPenetrationBlunt>324.76</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -107,12 +109,14 @@
     <defName>Bullet_127x108mm_HE</defName>
     <label>12.7x108mm bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>28</damageAmountBase>
+      <damageAmountBase>40</damageAmountBase>
       <armorPenetrationBase>1.05</armorPenetrationBase>
+	  <armorPenetrationSharp>12</armorPenetrationSharp>
+	  <armorPenetrationBlunt>324.76</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
-          <amount>18</amount>
+          <amount>24</amount>
         </li>
       </secondaryDamage>
     </projectile>
@@ -122,12 +126,14 @@
     <defName>Bullet_127x108mm_Incendiary</defName>
     <label>12.7x108mm bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>27</damageAmountBase>
+      <damageAmountBase>25</damageAmountBase>
       <armorPenetrationBase>1.05</armorPenetrationBase>
+	  <armorPenetrationSharp>23</armorPenetrationSharp>
+	  <armorPenetrationBlunt>324.76</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Flame_Secondary</def>
-          <amount>9</amount>
+          <amount>16</amount>
         </li>
       </secondaryDamage>
     </projectile>

--- a/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
+++ b/Defs/Ammo/HighCaliber/13.2x92mmSRTuF.xml
@@ -83,8 +83,10 @@
 		<defName>Bullet_132x92mmSRTuF_FMJ</defName>
 		<label>13.2mm TuF bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>46</damageAmountBase>
+			<damageAmountBase>40</damageAmountBase>
 			<armorPenetrationBase>0.898</armorPenetrationBase>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -92,8 +94,10 @@
 		<defName>Bullet_132x92mmSRTuF_AP</defName>
 		<label>13.2mm TuF bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>28</damageAmountBase>
+			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationBase>1.048</armorPenetrationBase>
+			<armorPenetrationSharp>23</armorPenetrationSharp>
+			<armorPenetrationBlunt>317.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/HighCaliber/2-Bore.xml
+++ b/Defs/Ammo/HighCaliber/2-Bore.xml
@@ -68,8 +68,10 @@
 		<defName>Bullet_2Bore_FMJ</defName>
 		<label>2-Bore bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>128</damageAmountBase>
+			<damageAmountBase>64</damageAmountBase>
 			<armorPenetrationBase>0.977</armorPenetrationBase>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
+			<armorPenetrationBlunt>480.34</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
+++ b/Defs/Ammo/HighCaliber/300WinchesterMagnum.xml
@@ -97,8 +97,10 @@
     <defName>Bullet_300WinchesterMagnum_FMJ</defName>
     <label>.300 Winchester Magnum bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>21</damageAmountBase>
+      <damageAmountBase>23</damageAmountBase>
 			<armorPenetrationBase>0.689</armorPenetrationBase>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
+			<armorPenetrationBlunt>110.76</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -108,6 +110,8 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>29</damageAmountBase>
 			<armorPenetrationBase>0.539</armorPenetrationBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>110.76</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -115,12 +119,14 @@
     <defName>Bullet_300WinchesterMagnum_Incendiary</defName>
     <label>.300 Winchester Magnum bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>13</damageAmountBase>
+      <damageAmountBase>15</damageAmountBase>
 			<armorPenetrationBase>0.839</armorPenetrationBase>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
+			<armorPenetrationBlunt>110.76</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Flame_Secondary</def>
-          <amount>4</amount>
+          <amount>9</amount>
         </li>
       </secondaryDamage>
     </projectile>

--- a/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338LapuaMagnum.xml
@@ -99,7 +99,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>26</damageAmountBase>
       <armorPenetrationBase>0.731</armorPenetrationBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
+      <armorPenetrationSharp>10</armorPenetrationSharp>
       <armorPenetrationBlunt>134.160</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -110,7 +110,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>33</damageAmountBase>
       <armorPenetrationBase>0.581</armorPenetrationBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
+      <armorPenetrationSharp>5</armorPenetrationSharp>
       <armorPenetrationBlunt>134.160</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
@@ -121,7 +121,7 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>16</damageAmountBase>
       <armorPenetrationBase>0.881</armorPenetrationBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
+      <armorPenetrationSharp>19</armorPenetrationSharp>
       <armorPenetrationBlunt>134.160</armorPenetrationBlunt>
       <secondaryDamage>
         <li>

--- a/Defs/Ammo/HighCaliber/338NormaMagnum.xml
+++ b/Defs/Ammo/HighCaliber/338NormaMagnum.xml
@@ -97,8 +97,10 @@
     <defName>Bullet_338Norma_FMJ</defName>
     <label>.338 Norma Magnum bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>24</damageAmountBase>
+      <damageAmountBase>25</damageAmountBase>
 			<armorPenetrationBase>0.716</armorPenetrationBase>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
+			<armorPenetrationBlunt>122.32</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -106,8 +108,10 @@
     <defName>Bullet_338Norma_HP</defName>
     <label>.338 Norma Magnum bullet (HP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>34</damageAmountBase>
+      <damageAmountBase>32</damageAmountBase>
 			<armorPenetrationBase>0.566</armorPenetrationBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>122.32</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -115,12 +119,14 @@
     <defName>Bullet_338Norma_Incendiary</defName>
     <label>.338 Norma Magnum bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>14</damageAmountBase>
+      <damageAmountBase>16</damageAmountBase>
 			<armorPenetrationBase>0.866</armorPenetrationBase>
+			<armorPenetrationSharp>19</armorPenetrationSharp>
+			<armorPenetrationBlunt>122.32</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Flame_Secondary</def>
-          <amount>5</amount>
+          <amount>10</amount>
         </li>
       </secondaryDamage>
     </projectile>

--- a/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
+++ b/Defs/Ammo/HighCaliber/408CheyenneTactical.xml
@@ -99,6 +99,8 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>34</damageAmountBase>
 	  <armorPenetrationBase>0.843</armorPenetrationBase>
+	  <armorPenetrationSharp>11</armorPenetrationSharp>
+	  <armorPenetrationBlunt>242</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -106,8 +108,10 @@
     <defName>Bullet_408CheyenneTactical_HP</defName>
     <label>.408 Cheyenne Tactical bullet (HP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>48</damageAmountBase>
+      <damageAmountBase>43</damageAmountBase>
 	  <armorPenetrationBase>0.693</armorPenetrationBase>
+	  <armorPenetrationSharp>5</armorPenetrationSharp>
+	  <armorPenetrationBlunt>242</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -115,12 +119,14 @@
     <defName>Bullet_408CheyenneTactical_Incendiary</defName>
     <label>.408 Cheyenne Tactical bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>20</damageAmountBase>
+      <damageAmountBase>21</damageAmountBase>
 	  <armorPenetrationBase>0.993</armorPenetrationBase>
+	  <armorPenetrationSharp>22</armorPenetrationSharp>
+	  <armorPenetrationBlunt>242</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Flame_Secondary</def>
-          <amount>7</amount>
+          <amount>13</amount>
         </li>
       </secondaryDamage>
     </projectile>

--- a/Defs/Ammo/HighCaliber/55Boys.xml
+++ b/Defs/Ammo/HighCaliber/55Boys.xml
@@ -83,8 +83,10 @@
 		<defName>Bullet_55Boys_FMJ</defName>
 		<label>.55 Boys bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>51</damageAmountBase>
+			<damageAmountBase>47</damageAmountBase>
 			<armorPenetrationBase>0.92</armorPenetrationBase>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>476.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -92,8 +94,10 @@
 		<defName>Bullet_55Boys_AP</defName>
 		<label>.55 Boys bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>31</damageAmountBase>
+			<damageAmountBase>30</damageAmountBase>
 			<armorPenetrationBase>1.07</armorPenetrationBase>
+			<armorPenetrationSharp>24</armorPenetrationSharp>
+			<armorPenetrationBlunt>476.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/HighCaliber/600NitroExpress.xml
+++ b/Defs/Ammo/HighCaliber/600NitroExpress.xml
@@ -82,8 +82,10 @@
     <defName>Bullet_600NitroExpress_FMJ</defName>
     <label>.600 Nitro Express bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>51</damageAmountBase>
+      <damageAmountBase>38</damageAmountBase>
 	  <armorPenetrationBase>0.83</armorPenetrationBase>
+	  <armorPenetrationSharp>11</armorPenetrationSharp>
+	  <armorPenetrationBlunt>222.96</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -91,8 +93,10 @@
     <defName>Bullet_600NitroExpress_HP</defName>
     <label>.600 Nitro Express bullet (HP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>71</damageAmountBase>
+      <damageAmountBase>48</damageAmountBase>
 	  <armorPenetrationBase>0.68</armorPenetrationBase>
+	  <armorPenetrationSharp>5</armorPenetrationSharp>
+	  <armorPenetrationBlunt>222.96</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
   

--- a/Defs/Ammo/HighCaliber/950JDJ.xml
+++ b/Defs/Ammo/HighCaliber/950JDJ.xml
@@ -68,8 +68,10 @@
 		<defName>Bullet_950JDJ_FMJ</defName>
 		<label>.950 JDJ bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>104</damageAmountBase>
+			<damageAmountBase>75</damageAmountBase>
 			<armorPenetrationBase>1.126</armorPenetrationBase>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationBlunt>1045.94</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Pistols/10mmAuto.xml
+++ b/Defs/Ammo/Pistols/10mmAuto.xml
@@ -99,7 +99,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBase>0.402</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>11.260</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -108,8 +108,10 @@
 		<defName>Bullet_10mmAuto_AP</defName>
 		<label>10mm Auto bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationBase>0.552</armorPenetrationBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>11.260</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -117,8 +119,10 @@
 		<defName>Bullet_10mmAuto_HP</defName>
 		<label>10mm Auto bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>24</damageAmountBase>
+			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationBase>0.252</armorPenetrationBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>11.260</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/13mmGyrojet.xml
+++ b/Defs/Ammo/Pistols/13mmGyrojet.xml
@@ -68,7 +68,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBase>0.373</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>10.2</armorPenetrationBlunt>
 			<spreadMult>8</spreadMult>
 		</projectile>

--- a/Defs/Ammo/Pistols/22LR.xml
+++ b/Defs/Ammo/Pistols/22LR.xml
@@ -83,7 +83,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationBase>0.189</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>4.06</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/22Short.xml
+++ b/Defs/Ammo/Pistols/22Short.xml
@@ -68,7 +68,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationBase>0.121</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>1.180</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/25ACP.xml
+++ b/Defs/Ammo/Pistols/25ACP.xml
@@ -67,10 +67,10 @@
 		<defName>Bullet_25ACP_FMJ</defName>
 		<label>.25 ACP bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>11</damageAmountBase>
+			<damageAmountBase>5</damageAmountBase>
 			<armorPenetrationBase>0.116</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>1.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/32ACP.xml
+++ b/Defs/Ammo/Pistols/32ACP.xml
@@ -97,7 +97,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationBase>0.187</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>3.980</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/357Magnum.xml
+++ b/Defs/Ammo/Pistols/357Magnum.xml
@@ -99,7 +99,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationBase>0.388</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.6</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -110,7 +110,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBase>0.538</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.6</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -121,7 +121,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>17</damageAmountBase>
 			<armorPenetrationBase>0.238</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>18.6</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/357SIG.xml
+++ b/Defs/Ammo/Pistols/357SIG.xml
@@ -99,8 +99,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBase>0.372</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>13.62</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -108,10 +108,10 @@
 		<defName>Bullet_357SIG_AP</defName>
 		<label>.357 SIG bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationBase>0.529</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>13.62</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -119,10 +119,10 @@
 		<defName>Bullet_357SIG_HP</defName>
 		<label>.357 SIG bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>14</damageAmountBase>
+			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationBase>0.229</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>13.62</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/380ACP.xml
+++ b/Defs/Ammo/Pistols/380ACP.xml
@@ -97,10 +97,10 @@
 		<defName>Bullet_380ACP_FMJ</defName>
 		<label>.380 ACP bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBase>0.279</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -108,10 +108,10 @@
 		<defName>Bullet_380ACP_AP</defName>
 		<label>.380 ACP bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>6</damageAmountBase>
+			<damageAmountBase>5</damageAmountBase>
 			<armorPenetrationBase>0.429</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -119,10 +119,10 @@
 		<defName>Bullet_380ACP_HP</defName>
 		<label>.380 ACP bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>14</damageAmountBase>
+			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBase>0.129</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/38ACP.xml
+++ b/Defs/Ammo/Pistols/38ACP.xml
@@ -83,8 +83,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBase>0.286</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>8.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -92,10 +92,10 @@
 		<defName>Bullet_38ACP_HP</defName>
 		<label>.38 ACP bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>14</damageAmountBase>
+			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationBase>0.136</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>8.58</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/38Special.xml
+++ b/Defs/Ammo/Pistols/38Special.xml
@@ -99,8 +99,8 @@
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
       <damageAmountBase>9</damageAmountBase>
       <armorPenetrationBase>0.257</armorPenetrationBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <armorPenetrationSharp>3</armorPenetrationSharp>
+      <armorPenetrationBlunt>6.94</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -108,10 +108,10 @@
     <defName>Bullet_38Special_AP</defName>
     <label>.38 Special bullet (AP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>5</damageAmountBase>
+      <damageAmountBase>6</damageAmountBase>
       <armorPenetrationBase>0.407</armorPenetrationBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <armorPenetrationSharp>7</armorPenetrationSharp>
+      <armorPenetrationBlunt>6.94</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -119,10 +119,10 @@
     <defName>Bullet_38Special_HP</defName>
     <label>.38 Special bullet (HP)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>13</damageAmountBase>
+      <damageAmountBase>12</damageAmountBase>
       <armorPenetrationBase>0.107</armorPenetrationBase>
-      <armorPenetrationSharp>0</armorPenetrationSharp>
-      <armorPenetrationBlunt>0</armorPenetrationBlunt>
+      <armorPenetrationSharp>2</armorPenetrationSharp>
+      <armorPenetrationBlunt>6.94</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 

--- a/Defs/Ammo/Pistols/40Rimfire.xml
+++ b/Defs/Ammo/Pistols/40Rimfire.xml
@@ -56,9 +56,9 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
 			<speed>26</speed>
-			<damageAmountBase>4</damageAmountBase>
+			<damageAmountBase>6</damageAmountBase>
 			<armorPenetrationBase>0.098</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>1</armorPenetrationSharp>
 			<armorPenetrationBlunt>1.360</armorPenetrationBlunt>
 			<dropsCasings>true</dropsCasings>
 		</projectile>

--- a/Defs/Ammo/Pistols/40SW.xml
+++ b/Defs/Ammo/Pistols/40SW.xml
@@ -99,7 +99,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBase>0.343</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>12.360</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -110,7 +110,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBase>0.493</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
 			<armorPenetrationBlunt>12.360</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -119,9 +119,9 @@
 		<defName>Bullet_40SW_HP</defName>
 		<label>.40 SW bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>16</damageAmountBase>
+			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationBase>0.193</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 			<armorPenetrationBlunt>12.360</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/454Casull.xml
+++ b/Defs/Ammo/Pistols/454Casull.xml
@@ -101,10 +101,10 @@
 		<defName>Bullet_454Casull_FMJ</defName>
 		<label>.454 Casull bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>25</damageAmountBase>
+			<damageAmountBase>21</damageAmountBase>
 			<armorPenetrationBase>0.548</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>53.82</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -112,10 +112,10 @@
 		<defName>Bullet_454Casull_AP</defName>
 		<label>.454 Casull bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
+			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationBase>0.698</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>53.82</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -123,10 +123,10 @@
 		<defName>Bullet_454Casull_HP</defName>
 		<label>.454 Casull bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>35</damageAmountBase>
+			<damageAmountBase>26</damageAmountBase>
 			<armorPenetrationBase>0.398</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>53.82</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/46x30mm.xml
+++ b/Defs/Ammo/Pistols/46x30mm.xml
@@ -99,8 +99,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBase>0.295</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>9.72</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -108,10 +108,10 @@
 		<defName>Bullet_46x30mm_AP</defName>
 		<label>4.6x30mm bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>6</damageAmountBase>
+			<damageAmountBase>5</damageAmountBase>
 			<armorPenetrationBase>0.445</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>9.72</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -119,10 +119,10 @@
 		<defName>Bullet_46x30mm_HP</defName>
 		<label>4.6x30mm bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBase>0.145</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>9.72</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/500SWMagnum.xml
+++ b/Defs/Ammo/Pistols/500SWMagnum.xml
@@ -82,9 +82,9 @@
 		<defName>Bullet_500SWMagnum_FMJ</defName>
 		<label>.500 Smith Wessen Magnum bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>21</damageAmountBase>
+			<damageAmountBase>24</damageAmountBase>
 			<armorPenetrationBase>0.563</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
 			<armorPenetrationBlunt>53.820</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -93,9 +93,9 @@
 		<defName>Bullet_500SWMagnum_HP</defName>
 		<label>.500 Smith Wessen Magnum bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>27</damageAmountBase>
+			<damageAmountBase>31</damageAmountBase>
 			<armorPenetrationBase>0.413</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
 			<armorPenetrationBlunt>53.820</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Pistols/58x21mmDAP92.xml
+++ b/Defs/Ammo/Pistols/58x21mmDAP92.xml
@@ -97,10 +97,10 @@
 		<defName>Bullet_58x21mmDAP92_FMJ</defName>
 		<label>5.8mm DAP92 bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>6</damageAmountBase>
+			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBase>0.276</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.92</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -108,10 +108,10 @@
 		<defName>Bullet_58x21mmDAP92_AP</defName>
 		<label>5.8mm DAP92 bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>4</damageAmountBase>
+			<damageAmountBase>5</damageAmountBase>
 			<armorPenetrationBase>0.426</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.92</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -119,10 +119,10 @@
 		<defName>Bullet_58x21mmDAP92_HP</defName>
 		<label>5.8mm DAP92 bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>8</damageAmountBase>
+			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBase>0.126</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.92</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/762x25mmTokarev.xml
+++ b/Defs/Ammo/Pistols/762x25mmTokarev.xml
@@ -99,7 +99,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBase>0.357</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>15.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -110,7 +110,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationBase>0.507</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
 			<armorPenetrationBlunt>15.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -121,6 +121,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationBase>0.207</armorPenetrationBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>15.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/763x25mmMauser.xml
+++ b/Defs/Ammo/Pistols/763x25mmMauser.xml
@@ -99,8 +99,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBase>0.311</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/8x22mmNambu.xml
+++ b/Defs/Ammo/Pistols/8x22mmNambu.xml
@@ -67,10 +67,10 @@
 		<defName>Bullet_8x22mmNambu_FMJ</defName>
 		<label>8mm Nambu bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBase>0.224</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.88</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/9x18mmMakarov.xml
+++ b/Defs/Ammo/Pistols/9x18mmMakarov.xml
@@ -97,8 +97,10 @@
 		<defName>Bullet_9x18mmMakarov_FMJ</defName>
 		<label>9mm Makarov bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>8</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBase>0.235</armorPenetrationBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -106,8 +108,10 @@
 		<defName>Bullet_9x18mmMakarov_AP</defName>
 		<label>9mm Makarov bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>5</damageAmountBase>
+			<damageAmountBase>6</damageAmountBase>
 			<armorPenetrationBase>0.385</armorPenetrationBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -117,6 +121,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBase>0.085</armorPenetrationBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.1</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Pistols/9x21mmGyurza.xml
+++ b/Defs/Ammo/Pistols/9x21mmGyurza.xml
@@ -97,10 +97,10 @@
 		<defName>Bullet_9x21mmGyurza_FMJ</defName>
 		<label>9mm Gyurza bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>9</damageAmountBase>
+			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBase>0.324</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>11.26</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -110,6 +110,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationBase>0.474</armorPenetrationBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>11.26</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -117,8 +119,10 @@
 		<defName>Bullet_9x21mmGyurza_HP</defName>
 		<label>9mm Gyurza bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
+			<damageAmountBase>14</damageAmountBase>
 			<armorPenetrationBase>0.174</armorPenetrationBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>11.26</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Pistols/FN57x28mm.xml
+++ b/Defs/Ammo/Pistols/FN57x28mm.xml
@@ -99,8 +99,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBase>0.312</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>10.980</armorPenetrationBlunt>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.98</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -110,8 +110,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>6</damageAmountBase>
 			<armorPenetrationBase>0.462</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>10.980</armorPenetrationBlunt>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.98</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -121,8 +121,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBase>0.162</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>10.980</armorPenetrationBlunt>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.98</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/127x55mmAR.xml
+++ b/Defs/Ammo/Rifle/127x55mmAR.xml
@@ -145,7 +145,7 @@
 		<label>12.7mm AR bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>21</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -155,7 +155,7 @@
 		<label>12.7mm AR bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -165,7 +165,7 @@
 		<label>12.7mm AR bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>27</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -183,7 +183,7 @@
           <amount>13</amount>
         </li>
       </secondaryDamage>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -199,7 +199,7 @@
           <amount>8</amount>
         </li>
       </secondaryDamage>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
@@ -209,7 +209,7 @@
 		<label>12.7mm AR bullet (Sabot)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>22</armorPenetrationSharp>
 			<armorPenetrationBlunt>51.340</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Defs/Ammo/Rifle/127x55mmSniper.xml
+++ b/Defs/Ammo/Rifle/127x55mmSniper.xml
@@ -99,10 +99,10 @@
 		<defName>Bullet_127x55mmSniper_FMJ</defName>
 		<label>12.7mm Sniper bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>31</damageAmountBase>
+			<damageAmountBase>23</damageAmountBase>
 			<armorPenetrationBase>0.623</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>66.14</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -110,10 +110,10 @@
 		<defName>Bullet_127x55mmSniper_AP</defName>
 		<label>12.7mm Sniper bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>19</damageAmountBase>
+			<damageAmountBase>14</damageAmountBase>
 			<armorPenetrationBase>0.773</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationBlunt>66.14</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -121,10 +121,10 @@
 		<defName>Bullet_127x55mmSniper_HP</defName>
 		<label>12.7mm Sniper bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>43</damageAmountBase>
+			<damageAmountBase>29</damageAmountBase>
 			<armorPenetrationBase>0.473</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>66.14</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/3006Springfield.xml
+++ b/Defs/Ammo/Rifle/3006Springfield.xml
@@ -97,10 +97,10 @@
 		<defName>Bullet_3006Springfield_FMJ</defName>
 		<label>.30-06 Springfield Cartridge (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>19</damageAmountBase>
+			<damageAmountBase>21</damageAmountBase>
 			<armorPenetrationBase>0.633</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>79.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -108,10 +108,10 @@
 		<defName>Bullet_3006Springfield_AP</defName>
 		<label>.30-06 Springfield Cartridge (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>11</damageAmountBase>
+			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationBase>0.783</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>16</armorPenetrationSharp>
+			<armorPenetrationBlunt>79.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -119,10 +119,10 @@
 		<defName>Bullet_3006Springfield_HP</defName>
 		<label>.30-06 Springfield Cartridge (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>27</damageAmountBase>
+			<damageAmountBase>26</damageAmountBase>
 			<armorPenetrationBase>0.483</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>79.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/300AACBlackout.xml
+++ b/Defs/Ammo/Rifle/300AACBlackout.xml
@@ -101,10 +101,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
+			<damageAmountBase>16</damageAmountBase>
 			<armorPenetrationBase>0.498</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -116,10 +116,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>9</damageAmountBase>
+			<damageAmountBase>10</damageAmountBase>
 			<armorPenetrationBase>0.648</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
+			<armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -131,10 +131,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>21</damageAmountBase>
+			<damageAmountBase>20</damageAmountBase>
 			<armorPenetrationBase>0.348</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>36.46</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/30Carbine.xml
+++ b/Defs/Ammo/Rifle/30Carbine.xml
@@ -83,10 +83,10 @@
 		<defName>Bullet_30Carbine_FMJ</defName>
 		<label>.30 Carbine bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>13</damageAmountBase>
+			<damageAmountBase>14</damageAmountBase>
 			<armorPenetrationBase>0.442</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>25.74</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -96,8 +96,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
 			<armorPenetrationBase>0.292</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
-			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>25.74</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Defs/Ammo/Rifle/44-40Winchester.xml
+++ b/Defs/Ammo/Rifle/44-40Winchester.xml
@@ -67,8 +67,10 @@
 		<defName>Bullet_44-40Winchester_FMJ</defName>
 		<label>.44-40 Winchester bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>16</damageAmountBase>
+			<damageAmountBase>14</damageAmountBase>
 			<armorPenetrationBase>0.389</armorPenetrationBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>18.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/4570Gov.xml
+++ b/Defs/Ammo/Rifle/4570Gov.xml
@@ -97,8 +97,10 @@
 		<defName>Bullet_4570Gov_FMJ</defName>
 		<label>.45-70 Government Cartridge (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>25</damageAmountBase>
+			<damageAmountBase>20</damageAmountBase>
 			<armorPenetrationBase>0.56</armorPenetrationBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -106,8 +108,10 @@
 		<defName>Bullet_4570Gov_AP</defName>
 		<label>.45-70 Government Cartridge (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
+			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationBase>0.71</armorPenetrationBase>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -115,8 +119,10 @@
 		<defName>Bullet_4570Gov_HP</defName>
 		<label>.45-70 Government Cartridge (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>35</damageAmountBase>
+			<damageAmountBase>25</damageAmountBase>
 			<armorPenetrationBase>0.41</armorPenetrationBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>47.32</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/473x33mmCaseless.xml
+++ b/Defs/Ammo/Rifle/473x33mmCaseless.xml
@@ -96,8 +96,10 @@
 		<defName>Bullet_473x33mmCaseless_FMJ</defName>
 		<label>4.73mm Caseless bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>8</damageAmountBase>
+			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBase>0.453</armorPenetrationBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>28.5</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -105,8 +107,10 @@
 		<defName>Bullet_473x33mmCaseless_AP</defName>
 		<label>4.73mm Caseless bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>5</damageAmountBase>
+			<damageAmountBase>8</damageAmountBase>
 			<armorPenetrationBase>0.603</armorPenetrationBase>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>28.5</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -114,8 +118,10 @@
 		<defName>Bullet_473x33mmCaseless_HP</defName>
 		<label>4.73mm Caseless bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>11</damageAmountBase>
+			<damageAmountBase>16</damageAmountBase>
 			<armorPenetrationBase>0.303</armorPenetrationBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>28.5</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/56-56Spencer.xml
+++ b/Defs/Ammo/Rifle/56-56Spencer.xml
@@ -57,7 +57,7 @@
 			<damageDef>Bullet</damageDef>
 			<damageAmountBase>18</damageAmountBase>
 			<armorPenetrationBase>0.466</armorPenetrationBase>
-			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
 			<armorPenetrationBlunt>30.360</armorPenetrationBlunt>
 			<speed>73</speed>
 			<dropsCasings>true</dropsCasings>

--- a/Defs/Ammo/Rifle/58x42mmDBP10.xml
+++ b/Defs/Ammo/Rifle/58x42mmDBP10.xml
@@ -101,8 +101,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>12</damageAmountBase>
+			<damageAmountBase>14</damageAmountBase>
 			<armorPenetrationBase>0.505</armorPenetrationBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>35.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -114,8 +116,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 			<armorPenetrationBase>0.655</armorPenetrationBase>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
+			<armorPenetrationBlunt>35.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -127,8 +131,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>17</damageAmountBase>
+			<damageAmountBase>18</damageAmountBase>
 			<armorPenetrationBase>0.355</armorPenetrationBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>35.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
+++ b/Defs/Ammo/Rifle/65x50mmSRArisaka.xml
@@ -97,8 +97,10 @@
 		<defName>Bullet_65x50mmSRArisaka_FMJ</defName>
 		<label>6.5mmSR Arisaka bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
+			<damageAmountBase>17</damageAmountBase>
 			<armorPenetrationBase>0.561</armorPenetrationBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>53.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -106,8 +108,10 @@
 		<defName>Bullet_65x50mmSRArisaka_AP</defName>
 		<label>6.5mmSR Arisaka bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>9</damageAmountBase>
+			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationBase>0.711</armorPenetrationBase>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationBlunt>53.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -115,8 +119,10 @@
 		<defName>Bullet_65x50mmSRArisaka_HP</defName>
 		<label>6.5mmSR Arisaka bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>21</damageAmountBase>
+			<damageAmountBase>22</damageAmountBase>
 			<armorPenetrationBase>0.411</armorPenetrationBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>53.36</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/7.92x57mmMauser.xml
+++ b/Defs/Ammo/Rifle/7.92x57mmMauser.xml
@@ -97,8 +97,10 @@
 		<defName>Bullet_792x51mmMauser_FMJ</defName>
 		<label>7.62mm Mauser bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>23</damageAmountBase>
+			<damageAmountBase>21</damageAmountBase>
 			<armorPenetrationBase>0.466</armorPenetrationBase>
+			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationBlunt>78.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -106,8 +108,10 @@
 		<defName>Bullet_792x51mmMauser_AP</defName>
 		<label>7.62mm Mauser bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>14</damageAmountBase>
+			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationBase>0.712</armorPenetrationBase>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+			<armorPenetrationBlunt>78.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -115,8 +119,10 @@
 		<defName>Bullet_792x51mmMauser_HP</defName>
 		<label>7.62mm Mauser bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>32</damageAmountBase>
+			<damageAmountBase>27</damageAmountBase>
 			<armorPenetrationBase>0.562</armorPenetrationBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>78.68</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/75x54mmFrench.xml
+++ b/Defs/Ammo/Rifle/75x54mmFrench.xml
@@ -97,8 +97,10 @@
 		<defName>Bullet_75x54mmFrench_FMJ</defName>
 		<label>7.5mm French bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>18</damageAmountBase>
+			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationBase>0.588</armorPenetrationBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>60.52</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -106,8 +108,10 @@
 		<defName>Bullet_75x54mmFrench_AP</defName>
 		<label>7.5mm French bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>11</damageAmountBase>
+			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBase>0.738</armorPenetrationBase>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationBlunt>60.52</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -115,8 +119,10 @@
 		<defName>Bullet_75x54mmFrench_HP</defName>
 		<label>7.5mm French bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>25</damageAmountBase>
+			<damageAmountBase>24</damageAmountBase>
 			<armorPenetrationBase>0.438</armorPenetrationBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>60.52</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/77x58mmArisaka.xml
+++ b/Defs/Ammo/Rifle/77x58mmArisaka.xml
@@ -97,8 +97,10 @@
 		<defName>Bullet_77x58mmArisaka_FMJ</defName>
 		<label>7.7mm Arisaka bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>18</damageAmountBase>
+			<damageAmountBase>19</damageAmountBase>
 			<armorPenetrationBase>0.583</armorPenetrationBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>60.24</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -106,8 +108,10 @@
 		<defName>Bullet_77x58mmArisaka_AP</defName>
 		<label>7.7mm Arisaka bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>11</damageAmountBase>
+			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBase>0.733</armorPenetrationBase>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
+			<armorPenetrationBlunt>60.24</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -115,8 +119,10 @@
 		<defName>Bullet_77x58mmArisaka_HP</defName>
 		<label>7.7mm Arisaka bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>25</damageAmountBase>
+			<damageAmountBase>24</damageAmountBase>
 			<armorPenetrationBase>0.433</armorPenetrationBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>60.24</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/792x33mmKurz.xml
+++ b/Defs/Ammo/Rifle/792x33mmKurz.xml
@@ -70,6 +70,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>16</damageAmountBase>
 			<armorPenetrationBase>0.501</armorPenetrationBase>
+			<armorPenetrationSharp>7</armorPenetrationSharp>
+			<armorPenetrationBlunt>37.54</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/8x50mmRLebel.xml
+++ b/Defs/Ammo/Rifle/8x50mmRLebel.xml
@@ -69,6 +69,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>20</damageAmountBase>
 			<armorPenetrationBase>0.605</armorPenetrationBase>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+			<armorPenetrationBlunt>68.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Defs/Ammo/Rifle/9x39mmSoviet.xml
@@ -97,8 +97,10 @@
 		<defName>Bullet_9x39mmSoviet_FMJ</defName>
 		<label>9mm Soviet bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>13</damageAmountBase>
+			<damageAmountBase>12</damageAmountBase>
 			<armorPenetrationBase>0.369</armorPenetrationBase>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
+			<armorPenetrationBlunt>13.18</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 	
@@ -106,8 +108,10 @@
 		<defName>Bullet_9x39mmSoviet_AP</defName>
 		<label>9mm Soviet bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>8</damageAmountBase>
+			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationBase>0.519</armorPenetrationBase>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+			<armorPenetrationBlunt>68.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 	
@@ -115,8 +119,10 @@
 		<defName>Bullet_9x39mmSoviet_HP</defName>
 		<label>9mm Soviet bullet (HP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>18</damageAmountBase>
+			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationBase>0.269</armorPenetrationBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>68.22</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 	

--- a/Defs/Ammo/Shell/20x110mmHispano.xml
+++ b/Defs/Ammo/Shell/20x110mmHispano.xml
@@ -98,8 +98,10 @@
     <defName>Bullet_20x110mmHispano_FMJ</defName>
     <label>20mm Hispano bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>85</damageAmountBase>
+      <damageAmountBase>74</damageAmountBase>
       <armorPenetrationBase>1.106</armorPenetrationBase>
+	  <armorPenetrationSharp>14</armorPenetrationSharp>
+	  <armorPenetrationBlunt>1242.52</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -107,12 +109,14 @@
     <defName>Bullet_20x110mmHispano_HE</defName>
     <label>20mm Hispano bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>51</damageAmountBase>
+      <damageAmountBase>74</damageAmountBase>
       <armorPenetrationBase>1.256</armorPenetrationBase>
+	  <armorPenetrationSharp>14</armorPenetrationSharp>
+	  <armorPenetrationBlunt>1242.52</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
-          <amount>34</amount>
+          <amount>45</amount>
         </li>
       </secondaryDamage>
     </projectile>
@@ -122,12 +126,14 @@
     <defName>Bullet_20x110mmHispano_Incendiary</defName>
     <label>20mm Hispano bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>51</damageAmountBase>
+      <damageAmountBase>47</damageAmountBase>
       <armorPenetrationBase>1.256</armorPenetrationBase>
+	  <armorPenetrationSharp>29</armorPenetrationSharp>
+	  <armorPenetrationBlunt>1242.52</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Flame_Secondary</def>
-          <amount>17</amount>
+          <amount>29</amount>
         </li>
       </secondaryDamage>
     </projectile>

--- a/Defs/Ammo/Shell/20x82mmMauser.xml
+++ b/Defs/Ammo/Shell/20x82mmMauser.xml
@@ -98,8 +98,10 @@
     <defName>Bullet_20x82mmMauser_FMJ</defName>
     <label>20mm Mauser bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>82</damageAmountBase>
+      <damageAmountBase>58</damageAmountBase>
       <armorPenetrationBase>1.061</armorPenetrationBase>
+	  <armorPenetrationSharp>14</armorPenetrationSharp>
+	  <armorPenetrationBlunt>596.16</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -107,12 +109,14 @@
     <defName>Bullet_20x82mmMauser_HE</defName>
     <label>20mm Mauser bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>49</damageAmountBase>
+      <damageAmountBase>58</damageAmountBase>
       <armorPenetrationBase>1.211</armorPenetrationBase>
+	  <armorPenetrationSharp>28</armorPenetrationSharp>
+	  <armorPenetrationBlunt>596.16</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
-          <amount>33</amount>
+          <amount>35</amount>
         </li>
       </secondaryDamage>
     </projectile>
@@ -122,12 +126,14 @@
     <defName>Bullet_20x82mmMauser_Incendiary</defName>
     <label>20mm Mauser bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>49</damageAmountBase>
+      <damageAmountBase>36</damageAmountBase>
       <armorPenetrationBase>1.211</armorPenetrationBase>
+	  <armorPenetrationSharp>28</armorPenetrationSharp>
+	  <armorPenetrationBlunt>596.16</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Flame_Secondary</def>
-          <amount>16</amount>
+          <amount>23</amount>
         </li>
       </secondaryDamage>
     </projectile>

--- a/Defs/Ammo/Shell/20x99mmShVAK.xml
+++ b/Defs/Ammo/Shell/20x99mmShVAK.xml
@@ -98,8 +98,10 @@
     <defName>Bullet_20x99mmRShVAK_FMJ</defName>
     <label>20mmR ShVAK bullet (FMJ)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>78</damageAmountBase>
+      <damageAmountBase>56</damageAmountBase>
       <armorPenetrationBase>1.012</armorPenetrationBase>
+	  <armorPenetrationSharp>13</armorPenetrationSharp>
+	  <armorPenetrationBlunt>540.00</armorPenetrationBlunt>
     </projectile>
   </ThingDef>
 
@@ -107,12 +109,14 @@
     <defName>Bullet_20x99mmRShVAK_HE</defName>
     <label>20mmR ShVAK bullet (HE)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>47</damageAmountBase>
+      <damageAmountBase>56</damageAmountBase>
       <armorPenetrationBase>1.162</armorPenetrationBase>
+	  <armorPenetrationSharp>13</armorPenetrationSharp>
+	  <armorPenetrationBlunt>540.00</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Bomb_Secondary</def>
-          <amount>31</amount>
+          <amount>33</amount>
         </li>
       </secondaryDamage>
     </projectile>
@@ -122,12 +126,14 @@
     <defName>Bullet_20x99mmRShVAK_Incendiary</defName>
     <label>20mmR ShVAK bullet (AP-I)</label>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
-      <damageAmountBase>47</damageAmountBase>
+      <damageAmountBase>35</damageAmountBase>
       <armorPenetrationBase>1.162</armorPenetrationBase>
+	  <armorPenetrationSharp>26</armorPenetrationSharp>
+	  <armorPenetrationBlunt>540.00</armorPenetrationBlunt>
       <secondaryDamage>
         <li>
           <def>Flame_Secondary</def>
-          <amount>16</amount>
+          <amount>22</amount>
         </li>
       </secondaryDamage>
     </projectile>

--- a/Defs/Ammo/Shotgun/20Gauge.xml
+++ b/Defs/Ammo/Shotgun/20Gauge.xml
@@ -134,6 +134,8 @@
 			<damageAmountBase>6</damageAmountBase>
 			<pelletCount>7</pelletCount>
 			<armorPenetrationBase>0.185</armorPenetrationBase>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>2.02</armorPenetrationBlunt>
 			<spreadMult>17.8</spreadMult>
 		</projectile>
 	</ThingDef>
@@ -164,6 +166,8 @@
 			<speed>120</speed>
 			<damageAmountBase>31</damageAmountBase>
 			<armorPenetrationBase>0.423</armorPenetrationBase>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>39.34</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -178,6 +182,8 @@
 			<damageDef>Beanbag</damageDef>
 			<damageAmountBase>4</damageAmountBase>
 			<armorPenetrationBase>0.107</armorPenetrationBase>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>1.70</armorPenetrationBlunt>
 			<spreadMult>2</spreadMult>
 		</projectile>
 	</ThingDef>
@@ -192,6 +198,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>EMP</damageDef>
 			<damageAmountBase>11</damageAmountBase>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   

--- a/Defs/Ammo/Shotgun/23x75mmR.xml
+++ b/Defs/Ammo/Shotgun/23x75mmR.xml
@@ -118,10 +118,13 @@
 			<damageAmountBase>9</damageAmountBase>
 			<pelletCount>12</pelletCount>
 			<armorPenetrationBase>0.249</armorPenetrationBase>
+			<armorPenetrationSharp>4</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.7</armorPenetrationBlunt>
 			<spreadMult>17.8</spreadMult>
 		</projectile>
 	</ThingDef>
-
+	
+	<!-- Could not find mass/velocity. Assuming halfish mass (85g) of 23mm ShVAK round and 12 gauge slug velocity -->
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base23x75mmRBullet">
 		<defName>Bullet_23x75mmR_Slug</defName>
 		<label>shotgun slug</label>
@@ -130,8 +133,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>53</damageAmountBase>
+			<damageAmountBase>38</damageAmountBase>
 			<armorPenetrationBase>0.503</armorPenetrationBase>
+			<armorPenetrationSharp>11</armorPenetrationSharp>
+			<armorPenetrationBlunt>149.94</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -147,6 +152,8 @@
 			<damageDef>Beanbag</damageDef>
 			<damageAmountBase>7</damageAmountBase>
 			<armorPenetrationBase>0.141</armorPenetrationBase>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>10.11</armorPenetrationBlunt>
 			<spreadMult>2</spreadMult>
 		</projectile>
 	</ThingDef>
@@ -161,6 +168,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>EMP</damageDef>
 			<damageAmountBase>21</damageAmountBase>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>26.56</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
   


### PR DESCRIPTION
Temporary-ish (until more accurate values are found/decided) patch for armor penetration values.
Armor rating sharp based on old FMJ APx13 for sharp for FMJ, then adjusted for new values for AP/HP etc. rounds.

Armor rating blunt/damage based on table stats, barring 12gauge charge, which was unadjusted damage wise.