### PR TITLE
Girls frontline Weapon pack patch + ammodef

### DIFF
--- a/Defs/Ammo/HighCaliber/15.2x169mm.xml
+++ b/Defs/Ammo/HighCaliber/15.2x169mm.xml
@@ -1,0 +1,124 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <ThingCategoryDef>
+    <defName>Ammo152x169mm</defName>
+    <label>15.2x169mm</label>
+    <parent>AmmoHighCaliber</parent>
+    <iconPath>UI/Icons/ThingCategories/CaliberHighCaliber</iconPath>
+  </ThingCategoryDef>
+	
+	<!-- ==================== AmmoSet ========================== -->
+
+  <CombatExtended.AmmoSetDef>
+    <defName>AmmoSet_152x169mm</defName>
+    <label>15.2x169mm</label>
+    <ammoTypes>
+      <Ammo_152x169mm_Sabot>Bullet_152x169mm_Sabot</Ammo_152x169mm_Sabot>
+    </ammoTypes>
+  </CombatExtended.AmmoSetDef>
+	
+	<!-- ==================== Ammo ========================== -->
+
+  <ThingDef Class="CombatExtended.AmmoDef" Name="152x169mmBase" ParentName="SmallAmmoBase" Abstract="True">
+    <description>Prototype smoothbore cartritge designed for anti-material use.</description>
+    <statBases>
+	  <Mass>0.185</Mass>
+	  <Bulk>0.33</Bulk>
+    </statBases>
+    <tradeTags>
+      <li>CE_AutoEnableTrade</li>
+      <li>CE_AutoEnableCrafting</li>
+    </tradeTags>
+    <thingCategories>
+      <li>Ammo152x169mm</li>
+    </thingCategories>
+	<stackLimit>250</stackLimit>
+  </ThingDef>
+
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="152x169mmBase">
+    <defName>Ammo_152x169mm_Sabot</defName>
+    <label>15.2x169mm cartridge (Sabot)</label>
+    <graphicData>
+      <texPath>Things/Ammo/HighCaliber/Sabot</texPath>
+      <graphicClass>Graphic_StackCount</graphicClass>
+    </graphicData>
+    <statBases>
+      <MarketValue>0.91</MarketValue>
+    </statBases>
+    <ammoClass>Sabot</ammoClass>
+	<cookOffProjectile>Bullet_152x169mm_Sabot</cookOffProjectile>
+  </ThingDef>
+
+	
+	<!-- ================== Projectile ================== -->
+
+  <ThingDef Class="CombatExtended.AmmoDef" Name="Base_152x169mm" ParentName="BaseBullet" Abstract="true">
+    <graphicData>
+      <texPath>Things/Projectile/Bullet_Big</texPath>
+      <graphicClass>Graphic_Single</graphicClass>
+    </graphicData>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageDef>Bullet</damageDef>
+      <speed>290</speed>
+    </projectile>
+  </ThingDef>
+  
+  <ThingDef Class="CombatExtended.AmmoDef" ParentName="Base_152x169mm">
+    <defName>Bullet_152x169mm_Sabot</defName>
+    <label> 152x169mm (Sabot)</label>
+    <projectile Class="CombatExtended.ProjectilePropertiesCE">
+      <damageAmountBase>18</damageAmountBase>
+	  <armorPenetrationSharp>63</armorPenetrationSharp>
+      <armorPenetrationBlunt>409.98</armorPenetrationBlunt>
+    </projectile>
+  </ThingDef>
+  
+	<!-- ==================== Recipes ========================== -->
+
+  <RecipeDef ParentName="AmmoRecipeBase">
+    <defName>MakeAmmo_152x169mm_Sabot</defName>
+    <label>make 152x169mm (Sabot) x200</label>
+    <description>Craft 200 152x169mm (Sabot) cartridges.</description>
+    <jobString>Making 152x169mm (Sabot) cartridges.</jobString>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Steel</li>
+          </thingDefs>
+        </filter>
+        <count>60</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Uranium</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Chemfuel</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
+      </li>	  
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Chemfuel</li>	  
+        <li>Steel</li>
+		<li>Uranium</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ammo_152x169mm_Sabot>200</Ammo_152x169mm_Sabot>
+    </products>
+	<workAmount>8400</workAmount>
+  </RecipeDef>
+
+	
+</Defs>

--- a/Defs/Ammo/HighCaliber/15.2x169mm.xml
+++ b/Defs/Ammo/HighCaliber/15.2x169mm.xml
@@ -21,7 +21,7 @@
 	<!-- ==================== Ammo ========================== -->
 
   <ThingDef Class="CombatExtended.AmmoDef" Name="152x169mmBase" ParentName="SmallAmmoBase" Abstract="True">
-    <description>Prototype smoothbore cartritge designed for anti-material use.</description>
+    <description>Prototype smoothbore cartridge designed for anti-material use.</description>
     <statBases>
 	  <Mass>0.185</Mass>
 	  <Bulk>0.33</Bulk>

--- a/Patches/Girls Frontline Weapon Pack/ThingsDef_Misc/GFWeapons.xml
+++ b/Patches/Girls Frontline Weapon Pack/ThingsDef_Misc/GFWeapons.xml
@@ -1,0 +1,796 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+  <Operation Class="PatchOperationSequence">
+	<operations>
+	  <li Class="PatchOperationFindMod">
+			
+		<mods><li>Girls' frontline Weapon Pack</li></mods>
+			
+		<match Class="PatchOperationSequence">
+		<operations>
+
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="G_M4A1_AR" or 
+				defName="G_M16A1_AR" or 
+				defName="G_AR15_AR" or 
+				defName="G_SOPMODII_AR" or 
+				defName="G_HK416_AR" or 
+				defName="G_NEGAV_MG" or 
+				defName="G_G11_AR" or 
+				defName="G_AK12_AR" or 
+				defName="G_AN94_AR" or
+				defName="G_RO635_SMG" or
+				defName="G_UMP9_SMG" or
+				defName="G_UMP40_SMG" or
+				defName="G_UMP45_SMG" or
+				defName="G_IWS2000_RF" or
+				defName="G_MobileFireSupportPlatform"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+						<label>stock</label>
+						<capacities>
+						<li>Blunt</li>
+						</capacities>
+						<power>8</power>
+						<cooldownTime>1.55</cooldownTime>
+						<chanceFactor>1.5</chanceFactor>
+						<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+						<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>barrel</label>
+							<capacities>
+							<li>Blunt</li>
+							</capacities>
+							<power>5</power>
+							<cooldownTime>2.02</cooldownTime>
+							<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+						<label>muzzle</label>
+							<capacities>
+							<li>Poke</li>
+							</capacities>
+							<power>8</power>
+							<cooldownTime>1.55</cooldownTime>
+							<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="G_JERICHO_HG"]/tools</xpath>
+				<value>
+					<tools>
+						<li Class="CombatExtended.ToolCE">
+							<label>grip</label>
+							<capacities>
+							<li>Blunt</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<chanceFactor>1.5</chanceFactor>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+						</li>
+						<li Class="CombatExtended.ToolCE">
+							<label>muzzle</label>
+							<capacities>
+							<li>Poke</li>
+							</capacities>
+							<power>2</power>
+							<cooldownTime>1.54</cooldownTime>
+							<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+							<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+						</li>
+					</tools>
+				</value>
+			</li> 
+			
+			<!--M4A1-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_M4A1_AR</defName>
+				<statBases>
+					<Bulk>7.56</Bulk>
+					<Mass>3.01</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<SwayFactor>1.14</SwayFactor>
+					<ShotSpread>0.1</ShotSpread>
+					<WorkToMake>33500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>40</Steel>
+					<Chemfuel>10</Chemfuel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.60</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<range>55</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>GF556NatoFire</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+			
+			<!--M16A1-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_M16A1_AR</defName>
+				<statBases>
+					<Bulk>10.03</Bulk>
+					<Mass>3.26</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<SwayFactor>1.33</SwayFactor>
+					<ShotSpread>0.07</ShotSpread>
+					<WorkToMake>30000</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>50</Steel>
+					<Chemfuel>10</Chemfuel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.53</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.1</warmupTime>
+					<range>55</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>GF556NatoFire</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+			
+			<!--AR 15-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_AR15_AR</defName>
+				<statBases>
+					<Bulk>9.05</Bulk>
+					<Mass>3.26</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.48</SightsEfficiency>
+					<SwayFactor>1.31</SwayFactor>
+					<ShotSpread>0.09</ShotSpread>
+					<WorkToMake>37000</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>45</Steel>
+					<Chemfuel>10</Chemfuel>
+					<ComponentIndustrial>7</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.53</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.5</warmupTime>
+					<range>55</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<soundCast>AR15Fire</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+			
+			<!--SOPMODII-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_SOPMODII_AR</defName>
+				<statBases>
+					<Bulk>7.56</Bulk>
+					<Mass>3.01</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<SwayFactor>1.14</SwayFactor>
+					<ShotSpread>0.1</ShotSpread>
+					<WorkToMake>33500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>40</Steel>
+					<Chemfuel>10</Chemfuel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.60</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<range>55</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>GF556NatoFire</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+			
+			<!--HK416_AR-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_HK416_AR</defName>
+				<statBases>
+					<Bulk>7.09</Bulk>
+					<Mass>3.12</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<SwayFactor>1.12</SwayFactor>
+					<ShotSpread>0.12</ShotSpread>
+					<WorkToMake>32500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>45</Steel>
+					<Chemfuel>5</Chemfuel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.57</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<range>48</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>GF556NatoFire</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+			
+			<!--Negev-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_NEGAV_MG</defName>
+				<statBases>
+					<Bulk>11.10</Bulk>
+					<Mass>7.65</Mass>
+					<RangedWeapon_Cooldown>0.55</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.0</SightsEfficiency>
+					<SwayFactor>1.25</SwayFactor>
+					<ShotSpread>0.08</ShotSpread>
+					<WorkToMake>38500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>80</Steel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>0.93</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+					<warmupTime>1.3</warmupTime>
+					<range>55</range>
+					<burstShotCount>10</burstShotCount>
+					<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+					<soundCast>GF556NatoFire</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>150</magazineSize>
+					<reloadTime>7.8</reloadTime>
+					<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>5</aimedBurstShotCount>
+					<aiUseBurstMode>FALSE</aiUseBurstMode>
+					<aiAimMode>SuppressFire</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+			
+			<!--G 11-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_G11_AR</defName>
+				<statBases>
+					<Bulk>7.50</Bulk>
+					<Mass>3.65</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.21</SightsEfficiency>
+					<SwayFactor>1.15</SwayFactor>
+					<ShotSpread>0.06</ShotSpread>
+					<WorkToMake>34000</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>45</Steel>
+					<Chemfuel>10</Chemfuel>
+					<ComponentIndustrial>8</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.30</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_473x33mmCaseless_FMJ</defaultProjectile>
+					<warmupTime>1.275</warmupTime>
+					<range>48</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<soundCast>G11Fire</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>50</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_473x33mmCaseless</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+			
+			<!--AK12-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_AK12_AR</defName>
+				<statBases>
+					<Bulk>7.25</Bulk>
+					<Mass>3.3</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<SwayFactor>1.28</SwayFactor>
+					<ShotSpread>0.09</ShotSpread>
+					<WorkToMake>32500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>40</Steel>
+					<Chemfuel>10</Chemfuel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.38</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<range>51</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<soundCast>AK12Fire</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>60</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_545x39mmSoviet</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+			
+			<!--AN94-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_AN94_AR</defName>
+				<statBases>
+					<Bulk>9.43</Bulk>
+					<Mass>3.85</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<SwayFactor>1.33</SwayFactor>
+					<ShotSpread>0.09</ShotSpread>
+					<WorkToMake>32500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>40</Steel>
+					<Chemfuel>10</Chemfuel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.38</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
+					<warmupTime>1</warmupTime>
+					<range>64</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<soundCast>AN94Fire</soundCast>
+					<soundCastTail>GunTail_Medium</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>45</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_545x39mmSoviet</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+			
+			<!--RO365-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_RO635_SMG</defName>
+				<statBases>
+					<Bulk>6.50</Bulk>
+					<Mass>2.61</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.0</SightsEfficiency>
+					<SwayFactor>0.99</SwayFactor>
+					<ShotSpread>0.12</ShotSpread>
+					<WorkToMake>29500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>45</Steel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.46</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>20</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+					<soundCast>9MMFIRE</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>32</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_9x19mmPara</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+			
+			<!--UMP9-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_UMP9_SMG</defName>
+				<statBases>
+					<Bulk>4.50</Bulk>
+					<Mass>2.3</Mass>
+					<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<SwayFactor>0.92</SwayFactor>
+					<ShotSpread>0.14</ShotSpread>
+					<WorkToMake>30500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>30</Steel>
+					<Chemfuel>10</Chemfuel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.41</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<range>20</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<soundCast>9MMFIRE</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_9x19mmPara</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>BlowbackOperation</researchPrerequisite>
+			</li>
+			
+			<!--Jericho-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_JERICHO_HG</defName>
+				<statBases>
+					<Bulk>2.07</Bulk>
+					<Mass>1.05</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>0.7</SightsEfficiency>
+					<SwayFactor>1.04</SwayFactor>
+					<ShotSpread>0.17</ShotSpread>
+					<WorkToMake>7000</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>25</Steel>
+					<ComponentIndustrial>3</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+					<warmupTime>0.6</warmupTime>
+					<range>12</range>
+					<soundCast>9MMFIRE</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>16</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_9x19mmPara</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+				<weaponTags>
+					<li>CE_OneHandedWeapon</li>
+					</weaponTags>
+				<researchPrerequisite>BlowbackOperation</researchPrerequisite>
+			</li>
+			
+			<!--UMP40-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_UMP40_SMG</defName>
+				<statBases>
+					<Bulk>4.50</Bulk>
+					<Mass>2.3</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<SwayFactor>0.92</SwayFactor>
+					<ShotSpread>0.14</ShotSpread>
+					<WorkToMake>30500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>30</Steel>
+					<Chemfuel>10</Chemfuel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>1.78</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_40SW_FMJ</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<range>20</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+					<soundCast>45ACPFIRE</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>30</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_40SW</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>BlowbackOperation</researchPrerequisite>
+			</li>
+			
+			<!--UMP45-->
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_UMP45_SMG</defName>
+				<statBases>
+					<Bulk>4.50</Bulk>
+					<Mass>2.5</Mass>
+					<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>1.1</SightsEfficiency>
+					<SwayFactor>0.92</SwayFactor>
+					<ShotSpread>0.14</ShotSpread>
+					<WorkToMake>30500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>30</Steel>
+					<Chemfuel>10</Chemfuel>
+					<ComponentIndustrial>6</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<recoilAmount>2.08</recoilAmount>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+					<warmupTime>0.5</warmupTime>
+					<range>15</range>
+					<burstShotCount>6</burstShotCount>
+					<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+					<soundCast>45ACPFIRE</soundCast>
+					<soundCastTail>GunTail_Light</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>25</magazineSize>
+					<reloadTime>4</reloadTime>
+					<ammoSet>AmmoSet_45ACP</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aimedBurstShotCount>3</aimedBurstShotCount>
+					<aiUseBurstMode>TRUE</aiUseBurstMode>
+					<aiAimMode>Snapshot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>BlowbackOperation</researchPrerequisite>
+			</li>
+			
+			<!--IWS2000-->
+
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_IWS2000_RF</defName>
+				<statBases>
+					<Bulk>19.00</Bulk>
+					<Mass>18.00</Mass>
+					<RangedWeapon_Cooldown>1.37</RangedWeapon_Cooldown>
+					<SightsEfficiency>2.6</SightsEfficiency>
+					<SwayFactor>2.59</SwayFactor>
+					<ShotSpread>0.01</ShotSpread>
+					<WorkToMake>45500</WorkToMake>
+				</statBases>
+				<costList>
+					<Steel>110</Steel>
+					<Chemfuel>30</Chemfuel>
+					<ComponentIndustrial>5</ComponentIndustrial>
+				</costList>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_152x169mm_Sabot</defaultProjectile>
+					<warmupTime>3.3</warmupTime>
+					<range>86</range>
+					<soundCast>GF50SniperFire</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>5</magazineSize>
+					<reloadTime>4.5</reloadTime>
+					<ammoSet>AmmoSet_152x169mm</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+				<researchPrerequisite>PrecisionRifling</researchPrerequisite>
+			</li>
+
+			<!--Mobile Fire Support Platform-->
+			
+			<li Class="PatchOperationFindMod">
+				<mods>
+					<li>SheathYourSword</li>
+				</mods>
+				<nomatch Class="PatchOperationRemove">
+					<xpath>Defs/ThingDef[defName="G_MobileFireSupportPlatform"]/comps/li[@Class="SYS.CompProperties_Sheath"]</xpath>
+				</nomatch>
+			</li>
+			
+			<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+				<defName>G_MobileFireSupportPlatform</defName>
+				<statBases>
+					<Bulk>20.00</Bulk>
+					<Mass>15.00</Mass>
+					<RangedWeapon_Cooldown>2.17</RangedWeapon_Cooldown>
+					<SightsEfficiency>1</SightsEfficiency>
+					<SwayFactor>3.20</SwayFactor>
+					<ShotSpread>0.07</ShotSpread>
+				</statBases>
+				<Properties>
+					<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_80x256mmFuel_Thermobaric</defaultProjectile>
+					<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+					<warmupTime>1.9</warmupTime>
+					<range>48</range>
+					<soundCast>MFSP</soundCast>
+					<soundCastTail>GunTail_Heavy</soundCastTail>
+					<muzzleFlashScale>9</muzzleFlashScale>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</Properties>
+				<AmmoUser>
+					<magazineSize>1</magazineSize>
+					<reloadTime>9.1</reloadTime>
+					<ammoSet>AmmoSet_80x256mmFuel</ammoSet>
+				</AmmoUser>
+				<FireModes>
+					<aiAimMode>AimedShot</aiAimMode>
+				</FireModes>
+			</li>
+			
+		</operations>
+		</match>	
+	  </li>
+	</operations>	
+  </Operation>
+</Patch>


### PR DESCRIPTION
Patch and ammo def for Girls' frontline Weapon Pack.
Included 15.2x169mm ammo def since it is techincally a real caliber.
Ammo spec:
Overall Length: 207mm
Base case diameter: 26mm
Bullet Case Mass: 150g
Bullet Diameter (sabot): 5.5mm
Muzzle Velocity: 1450m/s
Bullet Mass (sabot):19.5g
Penetration is guesswork based on 40mm RHA at 1000m, which seems to be the most commonly cited penetration of the gun.