### PR TITLE
Patch Modification for Android Tiers

### DIFF
--- a/Patches/Android Tiers/Hediffs/Hediffs_Android.xml
+++ b/Patches/Android Tiers/Hediffs/Hediffs_Android.xml
@@ -156,14 +156,29 @@
 		<li Class="PatchOperationAdd">
 			<xpath>Defs/HediffDef[defName="NoFreeWillAT"]/stages/li/statOffsets</xpath>
 			<value>
-				<Suppressability>-1</Suppressability>
+				<Suppressability>-5</Suppressability>
 			</value>
 		</li>
 		
 		<li Class="PatchOperationAdd">
 			<xpath>Defs/HediffDef[defName="SoldierMind"]/stages/li/statOffsets</xpath>
 			<value>
-				<Suppressability>-1</Suppressability>
+				<Suppressability>-5</Suppressability>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="SoldierMind"]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
+			<value>
+				<ShootingAccuracyPawn>0.05</ShootingAccuracyPawn>
+				<AimingAccuracy>0.025</AimingAccuracy>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="SoldierMind"]/stages/li/statOffsets/RangedWeapon_Cooldown</xpath>
+			<value>
+				<ReloadSpeed>0.25</ReloadSpeed>
 			</value>
 		</li>
 		
@@ -230,6 +245,232 @@
 						<count>60</count>
 					</li>
 				</ingredients>
+			</value>
+		</li>
+		
+		<!--Fractal Enhancement-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="VI"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="VI"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>0.75</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="VII"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="VII"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>1.05</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="VIII"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="VIII"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="IX"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="IX"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>3.75</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="X"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="X"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>4.5</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XI"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>3</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XI"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>5.25</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XII"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XII"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>6.75</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XIII"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>4.5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XIII"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>7.5</ArmorRating_Blunt>
+			</value>
+		</li>
+				
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XIV"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>4.5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XIV"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>7.5</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XV"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>4.5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XV"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>8.25</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XVI"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XVI"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>8.25</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XVII"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>5.5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XVII"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>8.25</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XVIII"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>5.5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XVIII"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>8.25</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XIX"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>5.5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XIX"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>8.25</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XX"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>5.5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="XX"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>8.25</ArmorRating_Blunt>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="Peak"]/statOffsets/ArmorRating_Sharp</xpath>
+			<value>
+					<ArmorRating_Sharp>6.5</ArmorRating_Sharp>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FractalPillAndroid"]/stages/li[label="Peak"]/statOffsets/ArmorRating_Blunt</xpath>
+			<value>
+					<ArmorRating_Blunt>11.25</ArmorRating_Blunt>
 			</value>
 		</li>
 		

--- a/Patches/Android Tiers/PawnkindDefs/PawnKinds_Android.xml
+++ b/Patches/Android Tiers/PawnkindDefs/PawnKinds_Android.xml
@@ -55,6 +55,18 @@
 							<min>12</min>
 							<max>12</max>
 						</primaryMagazineCount>
+						<sidearms>
+							<li>
+								<generateChance>1</generateChance>
+								<sidearmMoney>
+									<min>0</min>
+									<max>1250</max>
+								</sidearmMoney>
+								<weaponTags>
+									<li>CE_Sidearm_M7Mech</li>
+								</weaponTags>
+							</li>
+						</sidearms>
 					</li>
 				</value>
 			</li>

--- a/Patches/Android Tiers/ThingDef_Misc/Weapons_Guns.xml
+++ b/Patches/Android Tiers/ThingDef_Misc/Weapons_Guns.xml
@@ -195,7 +195,7 @@
 				</Properties>
 				
 				<AmmoUser>
-					<magazineSize>24</magazineSize>
+					<magazineSize>36</magazineSize>
 					<reloadTime>4</reloadTime>
 					<ammoSet>AmmoSet_12GaugeCharged</ammoSet>
 				</AmmoUser>
@@ -266,7 +266,7 @@
 							<power>68</power>
 							<cooldownTime>2.24</cooldownTime>
 							<armorPenetrationBlunt>28.13</armorPenetrationBlunt>
-							<armorPenetrationSharp>18.75</armorPenetrationSharp>
+							<armorPenetrationSharp>35.16</armorPenetrationSharp>
 						</li>
 						<li Class="CombatExtended.ToolCE">
 							<label>blade</label>
@@ -279,6 +279,32 @@
 							<armorPenetrationSharp>11.12</armorPenetrationSharp>
 						</li>
 					</tools>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_MechKnife"]/weaponTags</xpath>
+				<value>
+					<li>CE_Sidearm_M7Mech</li>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_MechKnife"]/statBases</xpath>
+				<value>
+					<Bulk>35</Bulk>
+					<MeleeCounterParryBonus>0.16</MeleeCounterParryBonus>
+					<MarketValue>1000</MarketValue>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_MechKnife"]</xpath>
+				<value>
+					<equippedStatOffsets>
+						<MeleeCritChance>0.01</MeleeCritChance>
+						<MeleeParryChance>0.12</MeleeParryChance>
+					</equippedStatOffsets>
 				</value>
 			</li>
 			


### PR DESCRIPTION
Patch adjustment for Android Tiers.

Added in fractal enhancement armor correction.
Adjusted implants: Increased the supressability reduction to account for consciousnessincreases and coward trait.
Tweaked the combat implant to have CE appropriate buffs.
Increased Mastiff clip size and increased mech knife stabbing AP.