### PR TITLE
Disable incompatible GraphicApparelDetour.dll detour injection.

### DIFF
--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -267,6 +267,7 @@
     <Compile Include="Harmony\Harmony-FloatMenuMakerMap.cs" />
     <Compile Include="Harmony\Harmony-GenRadial.cs" />
     <Compile Include="Harmony\Harmony-GlobalControls.cs" />
+    <Compile Include="Harmony\Harmony-GraphicApparelDetour.cs" />
     <Compile Include="Harmony\Harmony-HediffComp_TendDuration.cs" />
     <Compile Include="Harmony\Harmony-HediffWithComps.cs" />
     <Compile Include="Harmony\Harmony-Hediff_MissingPart.cs" />

--- a/Source/CombatExtended/Harmony/Harmony-GraphicApparelDetour.cs
+++ b/Source/CombatExtended/Harmony/Harmony-GraphicApparelDetour.cs
@@ -1,0 +1,59 @@
+﻿using Harmony;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Verse;
+
+
+namespace CombatExtended.Harmony
+{
+
+    [HarmonyPatch]
+    class GraphicApparelDetour_Disable
+    {
+        static readonly string logPrefix = Assembly.GetExecutingAssembly().GetName().Name + " :: " + typeof(GraphicApparelDetour_Disable).Name + " :: ";
+        static List<Assembly> target_asses = new List<Assembly>();
+
+        static bool Prepare()
+        {
+            foreach (var ass in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (ass.FullName.Contains("GraphicApparelDetour"))
+                {
+                    target_asses.Add(ass);
+                }
+            }
+            if (target_asses.Any())
+            {
+                return true;
+            }
+            return false;
+        }
+
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            foreach (var ass in target_asses)
+            {
+                foreach (var type in ass.GetTypes())
+                {
+                    MethodBase method_info = null;
+                    if (type.Name.Contains("InjectorThingy"))
+                    {
+                        method_info = AccessTools.Method(type, "InjectStuff");
+                    }
+                    if (method_info != null)
+                    {
+                        Log.Message($"{logPrefix}Disabling TryGetGraphicApparel detour injection in: {ass.FullName}");
+                        yield return method_info;
+                    }
+                }
+            }
+        }
+
+        static bool Prefix()
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
If GraphicApparelDetour.dll is found in the currently loaded assemblies, detour it's injection method. Fixes pawn layer rendering issues caused by mods including this assembly.