### PR TITLE
Fix fire never spreading while zero wind or indoors

### DIFF
--- a/Source/CombatExtended/Harmony/Harmony-Fire.cs
+++ b/Source/CombatExtended/Harmony/Harmony-Fire.cs
@@ -130,7 +130,7 @@ namespace CombatExtended.Harmony
         private static float GetWindMult(Fire fire)
         {
             var tracker = fire.Map.GetComponent<WeatherTracker>();
-            return Mathf.Sqrt(tracker.GetWindStrengthAt(fire.Position));
+            return Mathf.Max(1, Mathf.Sqrt(tracker.GetWindStrengthAt(fire.Position)));
         }
 
         private static IntVec3 GetRandWindShift(Fire fire, bool spreadFar)


### PR DESCRIPTION
Multiplier of zero was preventing fire from spreading at all if there isn't any wind to push it around.