### PR TITLE
Apparel compatibility for BBBodySupport, move compatibility patches to subdir.

### DIFF
--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -261,13 +261,14 @@
     <Compile Include="CombatExtended\Verbs\Verb_MarkForArtilleryCE.cs" />
     <Compile Include="CombatExtended\Verbs\Verb_ShootMortarCE.cs" />
     <Compile Include="CombatExtended\Verbs\Verb_ShootCEOneUse.cs" />
+    <Compile Include="Harmony\Compatibility\Harmony-BBBodySupport.cs" />
     <Compile Include="Harmony\Harmony-BuildingProperties.cs" />
     <Compile Include="Harmony\Harmony-DamageWorker_AddInjury.cs" />
     <Compile Include="Harmony\Harmony-Fire.cs" />
     <Compile Include="Harmony\Harmony-FloatMenuMakerMap.cs" />
     <Compile Include="Harmony\Harmony-GenRadial.cs" />
     <Compile Include="Harmony\Harmony-GlobalControls.cs" />
-    <Compile Include="Harmony\Harmony-GraphicApparelDetour.cs" />
+    <Compile Include="Harmony\Compatibility\Harmony-GraphicApparelDetour.cs" />
     <Compile Include="Harmony\Harmony-HediffComp_TendDuration.cs" />
     <Compile Include="Harmony\Harmony-HediffWithComps.cs" />
     <Compile Include="Harmony\Harmony-Hediff_MissingPart.cs" />

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony-BBBodySupport.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony-BBBodySupport.cs
@@ -24,7 +24,7 @@ namespace CombatExtended.Harmony.Compatibility
 
         static bool Prepare()
         {
-            if (ass.FullName.Contains("BBBodySupport"))
+            if (ass?.FullName.Contains("BBBodySupport") ?? false)
             {
                 return true;
             }

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony-BBBodySupport.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony-BBBodySupport.cs
@@ -1,0 +1,92 @@
+﻿using Harmony;
+using RimWorld;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Verse;
+using System.Reflection.Emit;
+using System;
+
+namespace CombatExtended.Harmony.Compatibility
+{
+    [HarmonyPatch]
+    class Harmony_Compat_BBBodySupport
+    {
+        static readonly string logPrefix = Assembly.GetExecutingAssembly().GetName().Name + " :: ";
+        static Assembly ass = AppDomain.CurrentDomain.GetAssemblies().
+                                SingleOrDefault(assembly => assembly.
+                                GetName().Name == "BBBodySupport");
+
+        private static bool IsHeadwear(ApparelLayerDef layer)
+        {
+            return layer.GetModExtension<ApparelLayerExtension>()?.IsHeadwear ?? false;
+        }
+
+        static bool Prepare()
+        {
+            if (ass.FullName.Contains("BBBodySupport"))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            var found = false;
+            foreach (var t in ass.GetTypes())
+            {
+                foreach (var m in AccessTools.GetDeclaredMethods(t))
+                {
+                    if (m.Name.Contains("BBBody_ApparelPatch") || m.Name.Contains("BBBody_ApparelZombiefiedPatch"))
+                    {
+                        found = true;
+                        yield return m;
+                    }
+                }
+            }
+            if (found)
+            {
+                Log.Message($"{logPrefix}Applying compatibility patch for {ass.FullName}");
+            }
+        }
+
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            bool patched = false;
+            bool ready = false;
+
+            List<CodeInstruction> patch = new List<CodeInstruction>
+            {
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Ldind_Ref),
+                new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(Thing), nameof(Thing.def))),
+                new CodeInstruction(OpCodes.Ldfld, AccessTools.Field(typeof(ThingDef), nameof(ThingDef.apparel))),
+                new CodeInstruction(OpCodes.Callvirt, AccessTools.Property(typeof(ApparelProperties), nameof(ApparelProperties.LastLayer)).GetGetMethod()),
+                new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Harmony_Compat_BBBodySupport), nameof(IsHeadwear))),
+                new CodeInstruction(OpCodes.Brtrue)
+            };
+
+            foreach (var code in instructions)
+            {
+                yield return code;
+                if (!patched)
+                {
+                    if (code.opcode == OpCodes.Ldsfld)
+                    {
+                        ready = true;
+                    }
+                    if (ready && code.opcode == OpCodes.Bne_Un)
+                    {
+                        patch.Last().operand = code.operand;
+                        foreach (var c in patch)
+                        {
+                            yield return c;
+                        }
+                        patched = true;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony-GraphicApparelDetour.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony-GraphicApparelDetour.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using Verse;
 
 
-namespace CombatExtended.Harmony
+namespace CombatExtended.Harmony.Compatibility
 {
 
     [HarmonyPatch]


### PR DESCRIPTION
Adds apparel rendering compatibility for BBBodySupport, needed to support #921 

I took the soft touch with the logging, it's not an ancient DetoursLib job this time. And opinions on patching approaches aside, the prefix was written to detour for it's particular case only(which made it simple to patch).

Also moved this and the GraphicApparelDetour patch to a subdir and nested namespace, to avoid clutter.

Edit: Forgot to mention, this is currently dependent on author of BBBody removing a def file that overwrites the MiddleHead layer def(zozlin contacted the author). Seeing as that file is called "CE comp temp.xml", it's likely they'll oblige.