### PR TITLE
RunAndGun compatibility, prevent mobile reload attempts

### DIFF
--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -261,6 +261,7 @@
     <Compile Include="CombatExtended\Verbs\Verb_MarkForArtilleryCE.cs" />
     <Compile Include="CombatExtended\Verbs\Verb_ShootMortarCE.cs" />
     <Compile Include="CombatExtended\Verbs\Verb_ShootCEOneUse.cs" />
+    <Compile Include="Harmony\Compatibility\Harmony-RunAndGun.cs" />
     <Compile Include="Harmony\Harmony-BuildingProperties.cs" />
     <Compile Include="Harmony\Harmony-DamageWorker_AddInjury.cs" />
     <Compile Include="Harmony\Harmony-Fire.cs" />

--- a/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
+++ b/Source/CombatExtended/CombatExtended/Comps/CompAmmoUser.cs
@@ -22,6 +22,7 @@ namespace CombatExtended
 
         public Building_TurretGunCE turret;         // Cross-linked from CE turret
 
+        internal static Type rgStance = null;       // RunAndGun compatibility, set in relevent patch if needed
         #endregion
 
         #region Properties
@@ -294,6 +295,10 @@ namespace CombatExtended
                 turret.TryOrderReload();
                 return;
             }
+
+            // R&G compatibility, prevents an initial attempt to reload while moving
+            if (Wielder.stances.curStance.GetType() == rgStance)
+                return;
 
             if (UseAmmo)
             {

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony-RunAndGun.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony-RunAndGun.cs
@@ -1,0 +1,98 @@
+﻿using Harmony;
+using RimWorld;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Verse;
+using System.Reflection.Emit;
+using System;
+
+
+namespace CombatExtended.Harmony.Compatibility
+{
+    [HarmonyPatch]
+    class Harmony_Compat_RunAndGun
+    {
+        static readonly string logPrefix = Assembly.GetExecutingAssembly().GetName().Name + " :: ";
+        static readonly Assembly ass = AppDomain.CurrentDomain.GetAssemblies().
+                                        SingleOrDefault(assembly => assembly.GetName().Name == "RunAndGun");
+        static MethodBase targetMethod = null;
+        static Type Stance_RunAndGun = null;
+
+        internal static bool Prepare()
+        {
+            HarmonyInstance.DEBUG = true;
+            if (ass != null)
+            {
+                foreach (var t in ass.GetTypes())
+                {
+                    if (t.Name == "Verb_TryStartCastOn")
+                    {
+                        targetMethod = AccessTools.Method(t, "Prefix");
+                    }
+                    if (t.Name == "Stance_RunAndGun")
+                    {
+                        Stance_RunAndGun = t;
+                        CompAmmoUser.rgStance = t;
+                    }
+                }
+                if (targetMethod == null || Stance_RunAndGun == null)
+                {
+                    Log.Error($"{logPrefix}Failed to find target method while attempting to patch RunAndGun.");
+                    return false;
+                }
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        internal static MethodBase TargetMethod()
+        {
+            Log.Message($"{logPrefix}Applying compatibility patch for {ass.FullName}");
+            return targetMethod;
+        }
+        
+        internal static IEnumerable<CodeInstruction> Transpiler(ILGenerator gen, IEnumerable<CodeInstruction> instructions)
+        {
+            bool patched = false;
+            bool ready = false;
+
+            List<CodeInstruction> patch = new List<CodeInstruction>
+            {
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(Harmony_Compat_RunAndGun), nameof(CanBeFiredNow))),
+                new CodeInstruction(OpCodes.Brfalse)
+            };
+
+            foreach (var code in instructions)
+            {
+                yield return code;
+                if (!patched)
+                {
+                    if (code.opcode == OpCodes.Isinst && code.operand == Stance_RunAndGun)
+                    {
+                        ready = true;
+                    }
+                    if (ready && code.opcode == OpCodes.Brtrue)
+                    {
+                        patch.Last().operand = code.operand;
+                        foreach (var c in patch)
+                        {
+                            yield return c;
+                        }
+                        patched = true;
+                    }
+                }
+            }
+        }
+
+        internal static bool CanBeFiredNow(Verb instance)
+        {
+            return instance.EquipmentSource.TryGetComp<CompAmmoUser>()?.CanBeFiredNow ?? true;
+        }
+
+    }
+}

--- a/Source/CombatExtended/Harmony/Compatibility/Harmony-RunAndGun.cs
+++ b/Source/CombatExtended/Harmony/Compatibility/Harmony-RunAndGun.cs
@@ -1,5 +1,4 @@
 ﻿using Harmony;
-using RimWorld;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -21,7 +20,6 @@ namespace CombatExtended.Harmony.Compatibility
 
         internal static bool Prepare()
         {
-            HarmonyInstance.DEBUG = true;
             if (ass != null)
             {
                 foreach (var t in ass.GetTypes())
@@ -93,6 +91,5 @@ namespace CombatExtended.Harmony.Compatibility
         {
             return instance.EquipmentSource.TryGetComp<CompAmmoUser>()?.CanBeFiredNow ?? true;
         }
-
     }
 }


### PR DESCRIPTION
This seems like the easiest way to fix this. Being able to reload some weapons while moving would be cool and all, but that would only be realistic for some weapons. And more work than I'm interesting in putting in.

This approach, at least, fixes the conflict.

Closes #782 