### PR TITLE
Modified patches for Cupro's Alloys and Vanilla Armor Expanded.

### DIFF
--- a/Patches/CuprosAlloys/ThingDefs/Patch_Materials_Alloy_Utility.xml
+++ b/Patches/CuprosAlloys/ThingDefs/Patch_Materials_Alloy_Utility.xml
@@ -107,6 +107,12 @@
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[defName="CAL_Zamak"]/statBases/BluntDamageMultiplier</xpath>
 			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="CAL_Zamak"]/stuffProps/categories</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
 
 			<!-- ======== CAL_BismuthBronze ======== -->
 			<li Class="PatchOperationAdd">
@@ -132,6 +138,12 @@
 			</li>
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[defName="CAL_BismuthBronze"]/statBases/BluntDamageMultiplier</xpath>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="CAL_BismuthBronze"]/stuffProps/categories</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
 			</li>
 
 			<!-- ======== CAL_Bronze ======== -->
@@ -159,6 +171,12 @@
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[defName="CAL_Bronze"]/statBases/BluntDamageMultiplier</xpath>
 			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="CAL_Bronze"]/stuffProps/categories</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
+			</li>
 
 			<!-- ======== CAL_Cupronickel ======== -->
 			<li Class="PatchOperationAdd">
@@ -184,6 +202,12 @@
 			</li>
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[defName="CAL_Cupronickel"]/statBases/BluntDamageMultiplier</xpath>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="CAL_Cupronickel"]/stuffProps/categories</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
 			</li>
 
 			<!-- ======== CAL_StainlessSteel ======== -->
@@ -236,6 +260,12 @@
 			</li>
 			<li Class="PatchOperationRemove">
 				<xpath>Defs/ThingDef[defName="CAL_Hepatzion"]/statBases/BluntDamageMultiplier</xpath>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="CAL_Hepatzion"]/stuffProps/categories</xpath>
+				<value>
+					<li>Steeled</li>
+				</value>
 			</li>
 		</operations>
 	</Operation>

--- a/Patches/Vanilla Armour Expanded/Patch_Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/Patch_Armor_Spacer.xml
@@ -20,13 +20,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Headgear_LightMarineHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>11.84</ArmorRating_Sharp>
+					<ArmorRating_Sharp>12.8</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Headgear_LightMarineHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>30</ArmorRating_Blunt>
+					<ArmorRating_Blunt>27</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -85,13 +85,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Apparel_LightMarineArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>15.93</ArmorRating_Sharp>
+					<ArmorRating_Sharp>16</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Apparel_LightMarineArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>35</ArmorRating_Blunt>
+					<ArmorRating_Blunt>33.75</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -151,13 +151,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>19.2</ArmorRating_Sharp>
+					<ArmorRating_Sharp>20</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Headgear_HeavyMarineHelmet"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>56</ArmorRating_Blunt>
+					<ArmorRating_Blunt>48</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -225,13 +225,13 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/ArmorRating_Sharp</xpath>
 				<value>
-					<ArmorRating_Sharp>24.81</ArmorRating_Sharp>
+					<ArmorRating_Sharp>25</ArmorRating_Sharp>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Apparel_HeavyMarineArmor"]/statBases/ArmorRating_Blunt</xpath>
 				<value>
-					<ArmorRating_Blunt>58</ArmorRating_Blunt>
+					<ArmorRating_Blunt>60</ArmorRating_Blunt>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">

--- a/Patches/Vanilla Armour Expanded/Patch_Armor_Spacer.xml
+++ b/Patches/Vanilla Armour Expanded/Patch_Armor_Spacer.xml
@@ -71,6 +71,12 @@
 					<li>MiddleHead</li>
 				</value>
 			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_LightMarineHelmet"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<li>Eyes</li>
+				</value>
+			</li>
 
 			<!-- == VAE_Apparel_LightMarineArmor == -->
 			<!-- statBases -->

--- a/Patches/Vanilla Armour Expanded/Patch_Headgear_Industrial.xml
+++ b/Patches/Vanilla Armour Expanded/Patch_Headgear_Industrial.xml
@@ -14,15 +14,24 @@
 				<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/statBases/StuffEffectMultiplierArmor</xpath>
 				<value>
 					<Bulk>0.5</Bulk>
-					<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+					<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/layers</xpath>
 				<value>
 					<layers>
-						<li>MiddleHead</li>
+						<li>OnHead</li>
 					</layers>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="VAE_Headgear_Balaclava"]/apparel/bodyPartGroups</xpath>
+				<value>
+					<bodyPartGroups>
+						<li>UpperHead</li>
+						<li>Teeth</li>
+					</bodyPartGroups>
 				</value>
 			</li>
 
@@ -53,7 +62,6 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="VAE_Headgear_NightVisionGoggles"]/apparel/layers</xpath>
 				<value>
-					<li>OnHead</li>
 					<li>MiddleHead</li>
 					<li>StrappedHead</li>
 				</value>
@@ -106,7 +114,7 @@
 				<xpath>Defs/ThingDef[defName="VAE_Headgear_BallisticGoggles"]/apparel/layers</xpath>
 				<value>
 					<layers>
-						<li>OnHead</li>
+						<li>MiddleHead</li>
 					</layers>
 				</value>
 			</li>
@@ -154,7 +162,6 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="VAE_Headgear_HAZMATMask"]/apparel/layers</xpath>
 				<value>
-					<li>OnHead</li>
 					<li>MiddleHead</li>
 					<li>StrappedHead</li>
 				</value>


### PR DESCRIPTION
For Cupro's Alloys: made some alloys now be counted as "Steeled" materials (useable in armor vest production and alike);
For Vanilla Armor Expanded (or Vanilla Armour Expanded - i genuely don't care how it's supposed to be written because the name in the thumbnail of the mod and the name of the mod are different): tweaked armor values of spacer armor, modified coverage and layers of some headgear, made the balaclava thinner.