### PR TITLE
Polarisbloc and Vanilla/Advanced Bionics expansion patch

### DIFF
--- a/Patches/Polarisbloc Core Lab/HediffDefs/Hediffs_CombatChip.xml
+++ b/Patches/Polarisbloc Core Lab/HediffDefs/Hediffs_CombatChip.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+    <mods>
+        <li>Polarisbloc - Core LAB</li>
+    </mods>
+	<match Class="PatchOperationSequence">
+		<operations>
+		<!--Combat Chip modes-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="PolarisCombatChip_Currency"]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
+			<value>
+				<ShootingAccuracyPawn>0.2</ShootingAccuracyPawn>
+				<AimingAccuracy>0.1</AimingAccuracy>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="PolarisCombatChip_Sniper"]/stages/li/statOffsets/ShootingAccuracyPawn</xpath>
+			<value>
+				<ShootingAccuracyPawn>1</ShootingAccuracyPawn>
+				<AimingAccuracy>0.5</AimingAccuracy>
+				<ReloadSpeed>0.5</ReloadSpeed>
+				<Suppressability>-0.25</Suppressability>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="PolarisCombatChip_Scouter"]/stages/li/statOffsets/MeleeDodgeChance</xpath>
+			<value>
+				<MeleeDodgeChance>0.87</MeleeDodgeChance>
+				<MeleeCritChance>0.04</MeleeCritChance>
+				<MeleeParryChance>0.05</MeleeParryChance>
+				<Suppressability>-0.50</Suppressability>
+			</value>
+		</li>
+		
+		</operations>
+	</match>
+	</Operation>
+</Patch>
+

--- a/Patches/Vanilla Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
+++ b/Patches/Vanilla Bionics Expansion/HediffDefs/FSFAdvancedBionics_AddedParts.xml
@@ -15,7 +15,7 @@
 					<li Class="CombatExtended.ToolCE">
 					<label>claw</label>
 					<capacities>
-						<li>Slash</li>
+						<li>Scratch</li>
 					</capacities>
 					<power>25</power>
 					<cooldownTime>0.71</cooldownTime>
@@ -34,7 +34,7 @@
 					<li Class="CombatExtended.ToolCE">
 					<label>claw</label>
 					<capacities>
-						<li>Slash</li>
+						<li>Scratch</li>
 					</capacities>
 					<power>29</power>
 					<cooldownTime>0.59</cooldownTime>
@@ -85,6 +85,34 @@
 					<ArmorRating_Blunt>+6</ArmorRating_Blunt>
 					<ArmorRating_Heat>+3.84</ArmorRating_Heat>
 					<ArmorRating_Sharp>+4</ArmorRating_Sharp>
+				</statOffsets>
+			</value>
+		</li>
+		
+		<!--AI Chip Implants-->
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FSFAIChipMelee"]/stages/li/statOffsets</xpath>
+			<value>
+				<statOffsets>
+					<MeleeCritChance>0.15</MeleeCritChance>
+					<MeleeParryChance>0.1875</MeleeParryChance>
+					<MeleeDodgeChance>0.5</MeleeDodgeChance>
+					<MeleeHitChance>15.0</MeleeHitChance>
+					<Suppressability>-0.50</Suppressability>
+				</statOffsets>
+			</value>
+		</li>
+		
+		<li Class="PatchOperationReplace">
+			<xpath>Defs/HediffDef[defName="FSFAIChipShooting"]/stages/li/statOffsets</xpath>
+			<value>
+				<statOffsets>
+					<ShootingAccuracyPawn>+1</ShootingAccuracyPawn>
+					<AimingAccuracy>+0.5</AimingAccuracy>
+					<AimingDelayFactor>-0.25</AimingDelayFactor>
+					<Suppressability>-0.25</Suppressability>
+					<HuntingStealth>+0.25</HuntingStealth>
 				</statOffsets>
 			</value>
 		</li>

--- a/Patches/Vanilla Bionics Expansion/HediffDefs/FSFBionics_AddedParts.xml
+++ b/Patches/Vanilla Bionics Expansion/HediffDefs/FSFBionics_AddedParts.xml
@@ -15,7 +15,7 @@
 					<li Class="CombatExtended.ToolCE">
 					<label>claw</label>
 					<capacities>
-						<li>Slash</li>
+						<li>Scratch</li>
 					</capacities>
 					<power>21</power>
 					<cooldownTime>0.89</cooldownTime>


### PR DESCRIPTION
Switch vanilla bionics expansion and advanced bionics expansion power arms to scratch damage (to match power claw and since slash is being removed).
Add in CE stats for advanced bionics expansion implants.
Add in CE stats for Polarisbloc core lab implants.