### PR TITLE
Fix mortar charges not adjusting speed when changing targets

### DIFF
--- a/Source/CombatExtended/CombatExtended/Things/Smoke.cs
+++ b/Source/CombatExtended/CombatExtended/Things/Smoke.cs
@@ -98,7 +98,7 @@ namespace CombatExtended
 
         private void SpreadToAdjacentCells()
         {
-            if (density >= 1f)
+            if (density >= MinSpreadDensity)
             {
                 var freeCells = GenAdjFast.AdjacentCellsCardinal(Position).InRandomOrder().Where(CanMoveTo).ToList();
                 foreach (var freeCell in freeCells)

--- a/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
+++ b/Source/CombatExtended/CombatExtended/Verbs/Verb_LaunchProjectileCE.cs
@@ -72,19 +72,16 @@ namespace CombatExtended
         {
             get
             {
-                if (shotSpeed < 0)
+                if (CompCharges != null)
                 {
-                    if (CompCharges != null)
+                    if (CompCharges.GetChargeBracket((currentTarget.Cell - caster.Position).LengthHorizontal, ShotHeight, projectilePropsCE.Gravity, out var bracket))
                     {
-                        if (CompCharges.GetChargeBracket((currentTarget.Cell - caster.Position).LengthHorizontal, ShotHeight, projectilePropsCE.Gravity, out var bracket))
-                        {
-                            shotSpeed = bracket.x;
-                        }
+                        shotSpeed = bracket.x;
                     }
-                    else
-                    {
-                        shotSpeed = Projectile.projectile.speed;
-                    }
+                }
+                else
+                {
+                    shotSpeed = Projectile.projectile.speed;
                 }
                 return shotSpeed;
             }


### PR DESCRIPTION
For mortars (or any weapon that uses charges), the value of ShotSpeed is initialized on the first call to the property, and the calculated value is reused on every subsequent call. This causes problems when switching to targets at different ranges, as the weapon will keep using the speed calculated for its first shot, not the one it needs for the current shot. (e.g: fire a mortar at close range, the speed used will be 30, and now all rounds from that mortar will fly at 30 too, even when targeting locations that require higher speeds)