### PR TITLE
Setting fire-at-will to off cancels current/pending attack orders

### DIFF
--- a/Source/CombatExtended/CombatExtended.csproj
+++ b/Source/CombatExtended/CombatExtended.csproj
@@ -316,6 +316,7 @@
     <Compile Include="Harmony\Harmony-ShieldBelt.cs" />
     <Compile Include="Harmony\Harmony_PawnGraphicSet.cs" />
     <Compile Include="Harmony\Harmony_PawnRenderer.cs" />
+    <Compile Include="Harmony\Harmony_Pawn_DraftController.cs" />
     <Compile Include="Harmony\Harmony_SappersUtility.cs" />
     <Compile Include="Harmony\Harmony_Verb_BeatFire.cs" />
     <Compile Include="Harmony\TradeUtility.cs" />

--- a/Source/CombatExtended/Harmony/Harmony_Pawn_DraftController.cs
+++ b/Source/CombatExtended/Harmony/Harmony_Pawn_DraftController.cs
@@ -1,0 +1,34 @@
+﻿using Harmony;
+using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Verse.AI;
+
+namespace CombatExtended.Harmony
+{
+    [HarmonyPatch(typeof(Pawn_DraftController), nameof(Pawn_DraftController.FireAtWill), MethodType.Setter)]
+    class Harmony_Pawn_DraftController_StopAttackJobsOnHoldFire
+    {
+        [HarmonyPostfix]
+        public static void Postfix(Pawn_DraftController __instance, bool ___fireAtWillInt)
+        {
+            if (!___fireAtWillInt)
+            {
+                var jobTracker = __instance.pawn.jobs;
+                foreach (var queuedJob in jobTracker.jobQueue.ToList())
+                {
+                    if (queuedJob.job.def == JobDefOf.AttackStatic)
+                    {
+                        jobTracker.EndCurrentOrQueuedJob(queuedJob.job, JobCondition.Incompletable);
+                    }
+                }
+                if (__instance.pawn.CurJobDef == JobDefOf.AttackStatic)
+                {
+                    jobTracker.EndCurrentJob(JobCondition.Incompletable, true);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Makes colonists properly stand down when told to hold fire while performing a manual attack, instead of just resetting their aim progress.

Note: this is a tweak to vanilla behavior and not directly related to CE, so I'm not sure if it belongs here, but given combat is the main focus I figured it might be a worthwhile addition.