### PR TITLE
Update to non-weapon Android Tier patches

### DIFF
--- a/Patches/Android Tiers/Ammo/81mmMortar_Nanoshell.xml
+++ b/Patches/Android Tiers/Ammo/81mmMortar_Nanoshell.xml
@@ -4,6 +4,7 @@
 	<Operation Class="PatchOperationFindMod">
     <mods>
         <li>[1.0] Android tiers</li>
+		<li>Android tiers</li>
     </mods>
 	<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/Android Tiers/Bodies/Mod_Bodies_AT_ABird.xml
+++ b/Patches/Android Tiers/Bodies/Mod_Bodies_AT_ABird.xml
@@ -8,6 +8,7 @@
 			<li Class="PatchOperationFindMod">
 				<mods>
 					<li>[1.0] Android tiers</li>
+		<li>Android tiers</li>
 				</mods>
 				<match Class="PatchOperationSequence">
 					<operations>

--- a/Patches/Android Tiers/Bodies/Mod_Bodies_AT_K9.xml
+++ b/Patches/Android Tiers/Bodies/Mod_Bodies_AT_K9.xml
@@ -8,6 +8,7 @@
 			<li Class="PatchOperationFindMod">
 				<mods>
 					<li>[1.0] Android tiers</li>
+		<li>Android tiers</li>
 				</mods>
 				<match Class="PatchOperationSequence">
 					<operations>

--- a/Patches/Android Tiers/Bodies/Mod_Bodies_AT_M7Mech.xml
+++ b/Patches/Android Tiers/Bodies/Mod_Bodies_AT_M7Mech.xml
@@ -8,6 +8,7 @@
 			<li Class="PatchOperationFindMod">
 				<mods>
 					<li>[1.0] Android tiers</li>
+		<li>Android tiers</li>
 				</mods>
 				<match Class="PatchOperationSequence">
 					<operations>

--- a/Patches/Android Tiers/Bodies/Mod_Bodies_AT_Miniscyther.xml
+++ b/Patches/Android Tiers/Bodies/Mod_Bodies_AT_Miniscyther.xml
@@ -8,6 +8,7 @@
 			<li Class="PatchOperationFindMod">
 				<mods>
 					<li>[1.0] Android tiers</li>
+		<li>Android tiers</li>
 				</mods>
 				<match Class="PatchOperationSequence">
 					<operations>

--- a/Patches/Android Tiers/Bodies/Mod_Bodies_AT_Muff.xml
+++ b/Patches/Android Tiers/Bodies/Mod_Bodies_AT_Muff.xml
@@ -8,6 +8,7 @@
 			<li Class="PatchOperationFindMod">
 				<mods>
 					<li>[1.0] Android tiers</li>
+		<li>Android tiers</li>
 				</mods>
 				<match Class="PatchOperationSequence">
 					<operations>

--- a/Patches/Android Tiers/Bodies/Mod_Bodies_AT_T4Android.xml
+++ b/Patches/Android Tiers/Bodies/Mod_Bodies_AT_T4Android.xml
@@ -8,6 +8,7 @@
 			<li Class="PatchOperationFindMod">
 				<mods>
 					<li>[1.0] Android tiers</li>
+		<li>Android tiers</li>
 				</mods>
 				<match Class="PatchOperationSequence">
 					<operations>

--- a/Patches/Android Tiers/Hediffs/Hediffs_Android.xml
+++ b/Patches/Android Tiers/Hediffs/Hediffs_Android.xml
@@ -145,7 +145,7 @@
 					</capacities>
 					<power>44</power>
 					<cooldownTime>2.51</cooldownTime>
-					<armorPenetrationSharp>14.07</armorPenetrationSharp>
+					<armorPenetrationSharp>9.38</armorPenetrationSharp>
 					<armorPenetrationBlunt>45</armorPenetrationBlunt>
 				</li>
 				</tools>

--- a/Patches/Android Tiers/Hediffs/Hediffs_Android.xml
+++ b/Patches/Android Tiers/Hediffs/Hediffs_Android.xml
@@ -4,6 +4,7 @@
 	<Operation Class="PatchOperationFindMod">
     <mods>
         <li>[1.0] Android tiers</li>
+		<li>Android tiers</li>
     </mods>
 	<match Class="PatchOperationSequence">
 		<operations>
@@ -142,10 +143,10 @@
 					<capacities>
 						<li>Bite</li>
 					</capacities>
-					<power>31</power>
-					<cooldownTime>1.86</cooldownTime>
-					<armorPenetrationSharp>4.22</armorPenetrationSharp>
-					<armorPenetrationBlunt>13.5</armorPenetrationBlunt>
+					<power>44</power>
+					<cooldownTime>2.51</cooldownTime>
+					<armorPenetrationSharp>14.07</armorPenetrationSharp>
+					<armorPenetrationBlunt>45</armorPenetrationBlunt>
 				</li>
 				</tools>
 			</value>

--- a/Patches/Android Tiers/PawnkindDefs/PawnKinds_Android.xml
+++ b/Patches/Android Tiers/PawnkindDefs/PawnKinds_Android.xml
@@ -4,7 +4,8 @@
 		<success></success>
 		<operations>
 			<li Class="PatchOperationFindMod">
-			<mods><li>[1.0] Android tiers</li></mods>
+			<mods><li>[1.0] Android tiers</li>
+		<li>Android tiers</li></mods>
 			<match Class="PatchOperationSequence">
 			<operations>
 			

--- a/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers/ThingDef_Races/AlienRace_Androids.xml
@@ -4,7 +4,8 @@
 	  <operations>
 		<li Class="PatchOperationFindMod">
 		
-		  <mods><li>[1.0] Android tiers</li></mods>
+		  <mods><li>[1.0] Android tiers</li>
+		<li>Android tiers</li></mods>
 			<match Class="PatchOperationSequence">
 			  <operations>
 				<!--Test for comps-->

--- a/Patches/Android Tiers/ThingDef_Races/Races.xml
+++ b/Patches/Android Tiers/ThingDef_Races/Races.xml
@@ -4,7 +4,8 @@
 	  <operations>
 		<li Class="PatchOperationFindMod">
 		
-		  <mods><li>[1.0] Android tiers</li></mods>
+		  <mods><li>[1.0] Android tiers</li>
+		<li>Android tiers</li></mods>
 			<match Class="PatchOperationSequence">
 			  <operations>
 			    <!--Bodytype-->
@@ -407,11 +408,11 @@
 						<capacities>
 						  <li>Bite</li>
 						</capacities>
-						<power>22</power>
-						<cooldownTime>2.22</cooldownTime>
+						<power>26</power>
+						<cooldownTime>2.46</cooldownTime>
 						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-						<armorPenetrationSharp>1.13</armorPenetrationSharp>
-						<armorPenetrationBlunt>7.2</armorPenetrationBlunt>
+						<armorPenetrationSharp>1.5</armorPenetrationSharp>
+						<armorPenetrationBlunt>10.8</armorPenetrationBlunt>
 					  </li>
 					  <li Class="CombatExtended.ToolCE">
 						<label>head</label>


### PR DESCRIPTION
The latest update to android tiers renamed the mod in the about file. This adds that new name to the valid modnames for the patches.

Also some tweaks to the K9 robot dog and the advanced jaw, since the latter cannot be used by humanoid androids like I previously thought.