### PR TITLE
Fixes to android tiers patch and support for TX series

### DIFF
--- a/Patches/Android Tiers++/PawnkindDefs/PawnKinds_Android.xml
+++ b/Patches/Android Tiers++/PawnkindDefs/PawnKinds_Android.xml
@@ -4,18 +4,20 @@
 		<success></success>
 		<operations>
 			<li Class="PatchOperationFindMod">
-			<mods><li>Android Tiers++ Expansion</li></mods>
+			<mods><li>Android tiers - TX Series</li></mods>
 			<match Class="PatchOperationSequence">
 			<operations>
 			
 			<li Class="PatchOperationAddModExtension">
 				<xpath>Defs/PawnKindDef[
-					defName="ATPP_AndroidTX2RaiderFactionSpecific" or
-					defName="ATPP_AndroidTX3RaiderFactionSpecific" or
-					defName="ATPP_AndroidTX4RaiderFactionSpecific" or
-					defName="ATPP_AndroidTX2CollectiveSoldier" or
-					defName="ATPP_AndroidTX3CollectiveSoldier" or
-					defName="ATPP_AndroidTX4CollectiveSoldier"
+					@Name="ATPP_AndroidTX2RaiderBase" or
+					@Name="ATPP_AndroidTX2KRaiderBase" or
+					@Name="ATPP_AndroidTX3RaiderBase" or
+					@Name="ATPP_AndroidTX4RaiderBase" or
+					@Name="ATPP_AndroidTX2CollectiveBase" or
+					@Name="ATPP_AndroidTX2KCollectiveBase" or
+					@Name="ATPP_AndroidTX3CollectiveBase" or
+					@Name="ATPP_AndroidTX4CollectiveBase"
 					]</xpath>
 				<value>	
 					<li Class="CombatExtended.LoadoutPropertiesExtension">	

--- a/Patches/Android Tiers++/ThingDef_Races/AlienRace_Androids.xml
+++ b/Patches/Android Tiers++/ThingDef_Races/AlienRace_Androids.xml
@@ -4,7 +4,7 @@
 	  <operations>
 		<li Class="PatchOperationFindMod">
 		
-		  <mods><li>Android Tiers++ Expansion</li></mods>
+		  <mods><li>Android tiers - TX Series</li></mods>
 			<match Class="PatchOperationSequence">
 			  <operations>
 				<!--Test for comps-->
@@ -18,6 +18,22 @@
 					
 					<li Class="PatchOperationAdd">
 					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX"]</xpath>
+					  <value><comps /></value>
+					</li>
+					
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2ITX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2ITX"]</xpath>
 					  <value><comps /></value>
 					</li>
 					
@@ -42,6 +58,20 @@
 				  <success>Always</success>
 				  <operations>
 				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3ITX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3ITX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
 					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX"]/comps</xpath>
 					  <success>Invert</success>
 					</li>
@@ -52,12 +82,60 @@
 				  </operations>
 				</li>
 				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4ITX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4ITX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
+				<li Class="PatchOperationSequence">
+				  <success>Always</success>
+				  <operations>
+				    <li Class="PatchOperationTest">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KITX"]/comps</xpath>
+					  <success>Invert</success>
+					</li>
+					<li Class="PatchOperationAdd">
+					  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KITX"]</xpath>
+					  <value><comps /></value>
+					</li>
+				  </operations>
+				</li>
+				
 				<!--Multiple-->
 				
 				<li Class="PatchOperationAddModExtension">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or 
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="ATPP_Android2TX" or 
 				  defName="ATPP_Android3TX" or
-				  defName="ATPP_Android4TX"
+				  defName="ATPP_Android4TX" or
+				  defName="ATPP_Android2ITX" or 
+				  defName="ATPP_Android3ITX" or
+				  defName="ATPP_Android4ITX" or
+				  defName="ATPP_Android2KTX" or
+				  defName="ATPP_Android2KITX"
 				  ]</xpath>
 				  <value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
@@ -67,9 +145,15 @@
 				</li>
 				
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or 
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="ATPP_Android2TX" or 
 				  defName="ATPP_Android3TX" or
-				  defName="ATPP_Android4TX"
+				  defName="ATPP_Android4TX" or
+				  defName="ATPP_Android2ITX" or 
+				  defName="ATPP_Android3ITX" or
+				  defName="ATPP_Android4ITX" or
+				  defName="ATPP_Android2KTX" or
+				  defName="ATPP_Android2KITX"
 				  ]/comps</xpath>
 				  <value>
 				    <li>
@@ -78,11 +162,16 @@
 				  </value>
 				</li>
 				
-				<!--2/3/4 are all complex enough to have at least some intrinsic self presevation-->
+				<!--2/3/4 are all complex enough to have at least some intrinsic self presevation. 
+				2KXT Are purpose built combat units and as such do not.-->
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or 
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[
+				  defName="ATPP_Android2TX" or 
 				  defName="ATPP_Android3TX" or
-				  defName="ATPP_Android4TX"
+				  defName="ATPP_Android4TX" or
+				  defName="ATPP_Android2ITX" or 
+				  defName="ATPP_Android3ITX" or
+				  defName="ATPP_Android4ITX"
 				  ]/comps</xpath>
 				  <value>
 				    <li Class="CombatExtended.CompProperties_Suppressable" />
@@ -92,7 +181,7 @@
 				<!--T2-->
 				
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX"]/statBases</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or defName="ATPP_Android2ITX"]/statBases</xpath>
 				  <value>
 				    <MeleeDodgeChance>0.95</MeleeDodgeChance>
 					<MeleeCritChance>0.95</MeleeCritChance>
@@ -103,21 +192,21 @@
 				</li>
 				<!--1mm Steel-->
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX"]/statBases/ArmorRating_Sharp</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or defName="ATPP_Android2ITX"]/statBases/ArmorRating_Sharp</xpath>
 				  <value>
 				    <ArmorRating_Sharp>1</ArmorRating_Sharp>
 				  </value>
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX"]/statBases/ArmorRating_Blunt</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or defName="ATPP_Android2ITX"]/statBases/ArmorRating_Blunt</xpath>
 				  <value>
 				    <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
 				  </value>
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX"]/tools</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2TX" or defName="ATPP_Android2ITX"]/tools</xpath>
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
@@ -159,7 +248,7 @@
 				<!--T3-->
 				
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX"]/statBases</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX" or defName="ATPP_Android3ITX"]/statBases</xpath>
 				  <value>
 				    <MeleeDodgeChance>1</MeleeDodgeChance>
 					<MeleeCritChance>1.1</MeleeCritChance>
@@ -170,21 +259,21 @@
 				</li>
 				<!--1mm plasteel/1.5mm steel-->
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX"]/statBases/ArmorRating_Sharp</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX" or defName="ATPP_Android3ITX"]/statBases/ArmorRating_Sharp</xpath>
 				  <value>
 				    <ArmorRating_Sharp>3.5</ArmorRating_Sharp>
 				  </value>
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX"]/statBases/ArmorRating_Blunt</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX" or defName="ATPP_Android3ITX"]/statBases/ArmorRating_Blunt</xpath>
 				  <value>
 				    <ArmorRating_Blunt>4.75</ArmorRating_Blunt>
 				  </value>
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX"]/tools</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android3TX" or defName="ATPP_Android3ITX"]/tools</xpath>
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
@@ -226,7 +315,7 @@
 				<!--T4-->
 				
 				<li Class="PatchOperationAdd">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX"]/statBases</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX" or defName="ATPP_Android4ITX"]/statBases</xpath>
 				  <value>
 				    <MeleeDodgeChance>1.2</MeleeDodgeChance>
 					<MeleeCritChance>1.2</MeleeCritChance>
@@ -237,21 +326,21 @@
 				</li>
 				<!--2mm plasteel-->
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX"]/statBases/ArmorRating_Sharp</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX" or defName="ATPP_Android4ITX"]/statBases/ArmorRating_Sharp</xpath>
 				  <value>
 				    <ArmorRating_Sharp>4</ArmorRating_Sharp>
 				  </value>
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX"]/statBases/ArmorRating_Blunt</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX" or defName="ATPP_Android4ITX"]/statBases/ArmorRating_Blunt</xpath>
 				  <value>
 				    <ArmorRating_Blunt>6</ArmorRating_Blunt>
 				  </value>
 				</li>
 				
 				<li Class="PatchOperationReplace">
-				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX"]/tools</xpath>
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android4TX" or defName="ATPP_Android4ITX"]/tools</xpath>
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
@@ -285,6 +374,73 @@
 						<cooldownTime>2.49</cooldownTime>
 						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 						<armorPenetrationBlunt>2.025</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<!--T2K-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX" or defName="ATPP_Android2KITX"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>0.75</MeleeDodgeChance>
+					<MeleeCritChance>1.0</MeleeCritChance>
+					<MeleeParryChance>1.2</MeleeParryChance>
+					<Suppressability>0</Suppressability>
+					<SmokeSensitivity>0</SmokeSensitivity>
+				  </value>
+				</li>
+				<!--4mm Steel-->
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX" or defName="ATPP_Android2KITX"]/statBases/ArmorRating_Sharp</xpath>
+				  <value>
+				    <ArmorRating_Sharp>4</ArmorRating_Sharp>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX" or defName="ATPP_Android2KITX"]/statBases/ArmorRating_Blunt</xpath>
+				  <value>
+				    <ArmorRating_Blunt>6</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ATPP_Android2KTX" or defName="ATPP_Android2KITX"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>left fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.05</cooldownTime>
+						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>right fist</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>5</power>
+						<cooldownTime>2.05</cooldownTime>
+						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>1.75</armorPenetrationBlunt>
+					  </li>
+					  
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>10</power>
+						<cooldownTime>5.29</cooldownTime>
+						<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
 					  </li>
 					</tools>
 				  </value>

--- a/Patches/Android Tiers/Ammo/81mmMortar_Nanoshell.xml
+++ b/Patches/Android Tiers/Ammo/81mmMortar_Nanoshell.xml
@@ -4,6 +4,7 @@
 	<Operation Class="PatchOperationFindMod">
     <mods>
         <li>[1.0] Android tiers</li>
+		<li>Android tiers</li>
     </mods>
 	<match Class="PatchOperationSequence">
 		<operations>

--- a/Patches/Android Tiers/ThingDef_Misc/Weapons_Guns.xml
+++ b/Patches/Android Tiers/ThingDef_Misc/Weapons_Guns.xml
@@ -4,7 +4,10 @@
 		<success></success>
 		<operations>
 			<li Class="PatchOperationFindMod">
-			<mods><li>[1.0] Android tiers</li></mods>
+			<mods>
+			<li>[1.0] Android tiers</li>
+			<li>Android tiers</li>
+			</mods>
 			<match Class="PatchOperationSequence">
 			<operations>
 			<!-- ==========  40mm Cannon  =========== -->


### PR DESCRIPTION
## Additions

Added support for the TX and TXK series added by _Android tiers - TX Series_, which were previously part of the Android Tiers++ patch (which is now the TX series mod patchwise, as AT++ was intergrated barring the TX series, and the TX androids were the only thing that needed patching in the first place).

## Changes

Fixed missing mod requirements in PatchOperationFindMod operations for two patches that were missing the new one for 1.1.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
