### PR TITLE
Vanilla Vehicles Expanded Patches

### DIFF
--- a/Patches/Vanilla Animals Expanded - Vehicles/Bodies/Bodies_Car.xml
+++ b/Patches/Vanilla Animals Expanded - Vehicles/Bodies/Bodies_Car.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+		<operations>
+				
+			<!--Car Bodytype-->
+			
+			<li Class="PatchOperationFindMod">
+				<mods><li>Vanilla Vehicles Expanded</li></mods>
+				<match Class="PatchOperationSequence">
+					<operations>
+					<!--VAEAF Car-->
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="VAEAF_CarBody"]/corePart</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="VAEAF_CarBody"]/corePart/parts/li[def="VAEAF_FrontGrille"]/groups</xpath>
+						<value>
+							<li>CoveredByNaturalArmor</li>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="VAEAF_CarBody"]/corePart/parts/li[def="VAEAF_ChassisCentral"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</li>
+					
+					<li Class="PatchOperationAdd">
+						<xpath>/Defs/BodyDef[defName="VAEAF_CarBody"]/corePart/parts/li[def="VAEAF_ChassisCentral"]/parts/li[def="VAEAF_ChassisRear"]</xpath>
+						<value>
+							<groups>
+								<li>CoveredByNaturalArmor</li>
+							</groups>
+						</value>
+					</li>
+					
+					</operations>
+				</match>
+			</li>
+		</operations>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Animals Expanded - Vehicles/ThingDefs_Races/Races_AFVehicles.xml
+++ b/Patches/Vanilla Animals Expanded - Vehicles/ThingDefs_Races/Races_AFVehicles.xml
@@ -44,7 +44,7 @@
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
-						<label>head</label>
+						<label>front grille</label>
 						<capacities>
 						  <li>Blunt</li>
 						</capacities>
@@ -76,7 +76,7 @@
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
-						<label>head</label>
+						<label>front grille</label>
 						<capacities>
 						  <li>Blunt</li>
 						</capacities>
@@ -108,7 +108,7 @@
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
-						<label>head</label>
+						<label>front grille</label>
 						<capacities>
 						  <li>Blunt</li>
 						</capacities>
@@ -140,7 +140,7 @@
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
-						<label>head</label>
+						<label>front grille</label>
 						<capacities>
 						  <li>Blunt</li>
 						</capacities>
@@ -172,7 +172,7 @@
 				  <value>
 				    <tools>
 					  <li Class="CombatExtended.ToolCE">
-						<label>head</label>
+						<label>front grille</label>
 						<capacities>
 						  <li>Blunt</li>
 						</capacities>

--- a/Patches/Vanilla Animals Expanded - Vehicles/ThingDefs_Races/Races_AFVehicles.xml
+++ b/Patches/Vanilla Animals Expanded - Vehicles/ThingDefs_Races/Races_AFVehicles.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<Operation Class="PatchOperationSequence">
+	  <operations>
+		<li Class="PatchOperationFindMod">
+		
+		  <mods><li>Vanilla Vehicles Expanded</li></mods>
+			<match Class="PatchOperationSequence">
+			  <operations>
+			    <!--Bodytype-->
+				<li Class="PatchOperationAddModExtension">
+				  <xpath>/Defs/ThingDef[
+				  defName="VAEAF_CarFamily" or
+				  defName="VAEAF_CarDelivery" or
+				  defName="VAEAF_CarVintage" or
+				  defName="VAEAF_CarPickup" or
+				  defName="VAEAF_CarForklift"
+				  ]</xpath>
+				  <value>
+					<li Class="CombatExtended.RacePropertiesExtensionCE">
+					  <bodyShape>QuadrupedLow</bodyShape>
+					</li>
+				  </value>
+				</li>
+				
+				
+				
+				<!--Family Car-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="VAEAF_CarFamily"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>0.10</MeleeDodgeChance>
+					<MeleeCritChance>0.20</MeleeCritChance>
+					<MeleeParryChance>0.3</MeleeParryChance>
+					<SmokeSensitivity>0.05</SmokeSensitivity>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/ThingDef[defName="VAEAF_CarFamily"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>24</power>
+						<cooldownTime>3.17</cooldownTime>
+						<linkedBodyPartsGroup>VAEAF_FrontGrilleGroup</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>10</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<!--Delivery Truck-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="VAEAF_CarDelivery"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>0.10</MeleeDodgeChance>
+					<MeleeCritChance>0.20</MeleeCritChance>
+					<MeleeParryChance>0.3</MeleeParryChance>
+					<SmokeSensitivity>0.05</SmokeSensitivity>
+					<ArmorRating_Sharp>2</ArmorRating_Sharp>
+					<ArmorRating_Blunt>3</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/ThingDef[defName="VAEAF_CarDelivery"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>34</power>
+						<cooldownTime>5.96</cooldownTime>
+						<linkedBodyPartsGroup>VAEAF_FrontGrilleGroup</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>14.7</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<!--Vintage Car-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="VAEAF_CarVintage"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>0.15</MeleeDodgeChance>
+					<MeleeCritChance>0.25</MeleeCritChance>
+					<MeleeParryChance>0.35</MeleeParryChance>
+					<SmokeSensitivity>0.05</SmokeSensitivity>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					<ArmorRating_Blunt>6</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/ThingDef[defName="VAEAF_CarVintage"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>36</power>
+						<cooldownTime>2.54</cooldownTime>
+						<linkedBodyPartsGroup>VAEAF_FrontGrilleGroup</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>15.625</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<!--Pickup Truck-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="VAEAF_CarPickup"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>0.15</MeleeDodgeChance>
+					<MeleeCritChance>0.20</MeleeCritChance>
+					<MeleeParryChance>0.40</MeleeParryChance>
+					<SmokeSensitivity>0.05</SmokeSensitivity>
+					<ArmorRating_Sharp>4</ArmorRating_Sharp>
+					<ArmorRating_Blunt>6</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/ThingDef[defName="VAEAF_CarPickup"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>35</power>
+						<cooldownTime>3.51</cooldownTime>
+						<linkedBodyPartsGroup>VAEAF_FrontGrilleGroup</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>15</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<!--Pickup Truck-->
+				
+				<li Class="PatchOperationAdd">
+				  <xpath>/Defs/ThingDef[defName="VAEAF_CarForklift"]/statBases</xpath>
+				  <value>
+				    <MeleeDodgeChance>0.20</MeleeDodgeChance>
+					<MeleeCritChance>0.15</MeleeCritChance>
+					<MeleeParryChance>0.25</MeleeParryChance>
+					<SmokeSensitivity>0.05</SmokeSensitivity>
+					<ArmorRating_Sharp>1</ArmorRating_Sharp>
+					<ArmorRating_Blunt>1.5</ArmorRating_Blunt>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/ThingDef[defName="VAEAF_CarForklift"]/tools</xpath>
+				  <value>
+				    <tools>
+					  <li Class="CombatExtended.ToolCE">
+						<label>head</label>
+						<capacities>
+						  <li>Blunt</li>
+						</capacities>
+						<power>22</power>
+						<cooldownTime>6.65</cooldownTime>
+						<linkedBodyPartsGroup>VAEAF_FrontGrilleGroup</linkedBodyPartsGroup>
+						<armorPenetrationBlunt>9</armorPenetrationBlunt>
+					  </li>
+					</tools>
+				  </value>
+				</li>
+				
+				<li Class="PatchOperationReplace">
+				  <xpath>/Defs/ThingDef[defName="VAEAP_Leather_Car"]/statBases/StuffPower_Armor_Sharp</xpath>
+				  <value>
+				    <StuffPower_Armor_Sharp>0.05</StuffPower_Armor_Sharp>
+				  </value>
+				</li>
+				
+			  </operations>
+			</match>
+	    </li>
+		
+	  </operations>
+	</Operation>
+</Patch>

--- a/Patches/Vanilla Animals Expanded - Vehicles/ThingDefs_Races/Races_AFVehicles.xml
+++ b/Patches/Vanilla Animals Expanded - Vehicles/ThingDefs_Races/Races_AFVehicles.xml
@@ -18,7 +18,7 @@
 				  ]</xpath>
 				  <value>
 					<li Class="CombatExtended.RacePropertiesExtensionCE">
-					  <bodyShape>QuadrupedLow</bodyShape>
+					  <bodyShape>Vehicle</bodyShape>
 					</li>
 				  </value>
 				</li>


### PR DESCRIPTION
## Additions

Added patches for Vanilla Vehicles Expanded, for races and bodydef

## Reasoning

Melee is roughly centipede level for the "strongest" vehicles, scaling down for other ones. They are cars after all, and although it's probably a little over scaled, I don't think this is either a serious mod, or a serious concern. Also cars should be fairly dangerous if they run into a human, even if not at full speed.

## Testing

Check tests you have performed:
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
